### PR TITLE
Allow serialization of Execution object

### DIFF
--- a/js/src/messaging.ts
+++ b/js/src/messaging.ts
@@ -20,7 +20,7 @@ export class ExecutionError {
      * The raw traceback of the error.
      **/
     public tracebackRaw: string[]
-  ) {}
+  ) { }
 
   /**
    * Returns the traceback of the error as a string.
@@ -175,6 +175,25 @@ export class Result {
 
     return formats
   }
+
+  /**
+   * Returns the serializable representation of the result.
+   */
+  toJSON() {
+    return {
+      text: this.text,
+      html: this.html,
+      markdown: this.markdown,
+      svg: this.svg,
+      png: this.png,
+      jpeg: this.jpeg,
+      pdf: this.pdf,
+      latex: this.latex,
+      json: this.json,
+      javascript: this.javascript,
+      extra: this.extra
+    }
+  }
 }
 
 /**
@@ -208,7 +227,7 @@ export class Execution {
      * An Error object if an error occurred, null otherwise.
      */
     public error?: ExecutionError
-  ) {}
+  ) { }
 
   /**
    * Returns the text representation of the main result of the cell.
@@ -218,6 +237,17 @@ export class Execution {
       if (data.isMainResult) {
         return data.text
       }
+    }
+  }
+
+  /**
+   * Returns the serializable representation of the execution result.
+   */
+  toJSON() {
+    return {
+      results: this.results,
+      logs: this.logs,
+      error: this.error
     }
   }
 }
@@ -275,7 +305,7 @@ export class JupyterKernelWebSocket {
    * Does not start WebSocket connection!
    * You need to call connect() method first.
    */
-  constructor(private readonly url: string) {}
+  constructor(private readonly url: string) { }
 
   // public
   /**

--- a/js/src/messaging.ts
+++ b/js/src/messaging.ts
@@ -191,7 +191,7 @@ export class Result {
       latex: this.latex,
       json: this.json,
       javascript: this.javascript,
-      extra: this.extra
+      ...(Object.keys(this.extra).length > 0 ? { extra: this.extra } : {})
     }
   }
 }

--- a/python/e2b_code_interpreter/models.py
+++ b/python/e2b_code_interpreter/models.py
@@ -1,6 +1,6 @@
 import copy
 from typing import List, Optional, Iterable, Dict
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
 
 
 class Error(BaseModel):
@@ -233,6 +233,25 @@ class Execution(BaseModel):
         for d in self.results:
             if d.is_main_result:
                 return d.text
+
+    def to_json(self) -> str:
+        """
+        Returns the JSON representation of the Execution object.
+        """
+        return self.model_dump_json(exclude_none=True)
+
+    @field_serializer("results", when_used="json")
+    def serialize_results(results: List[Result]) -> List[Dict[str, str]]:
+        """
+        Serializes the results to JSON.
+        This method is used by the Pydantic JSON encoder.
+        """
+        serialized = []
+        for result in results:
+            serialized_dict = {key: result[key] for key in result.formats()}
+            serialized_dict['text'] = result.text
+            serialized.append(serialized_dict)
+        return serialized
 
 
 class KernelException(Exception):


### PR DESCRIPTION
The Execution objects in Python and JS are not serializable by default.
This PR adds the method for serialization to them.