### PR TITLE
[POC] - Code Interpreter with Jupyter Lab UI

### DIFF
--- a/python/e2b_code_interpreter/main.py
+++ b/python/e2b_code_interpreter/main.py
@@ -24,7 +24,7 @@ class CodeInterpreter(Sandbox):
     E2B code interpreter sandbox extension.
     """
 
-    template = "code-interpreter-stateful"
+    template = "code-interpreter-stateful-lab"
 
     def __init__(
         self,

--- a/python/e2b_code_interpreter/main.py
+++ b/python/e2b_code_interpreter/main.py
@@ -63,6 +63,9 @@ class JupyterExtension:
         self._connected_kernels: Dict[str, Future[JupyterKernelWebSocket]] = {}
         self._default_kernel_id: Optional[str] = None
 
+    def get_default_url(self) -> str:
+        return f"https://{self._sandbox.get_hostname(8888)}/doc/tree/RTC:default.ipynb"
+
     def exec_cell(
         self,
         code: str,

--- a/python/example.py
+++ b/python/example.py
@@ -4,8 +4,13 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-code = """
-import matplotlib.pyplot as plt
+code = """class Welcome:
+    def _repr_html_(self):
+        return "<h1>Welcome to the code interpreter!</h1>"
+Welcome()
+"""
+
+graph = """import matplotlib.pyplot as plt
 import numpy as np
 
 x = np.linspace(0, 20, 100)
@@ -14,18 +19,15 @@ y = np.sin(x)
 plt.plot(x, y)
 plt.show()
 
-x = np.linspace(0, 10, 100)
-
-plt.plot(x, y)
-plt.show()
-
 import pandas
 pandas.DataFrame({"a": [1, 2, 3]})
 """
 
-with CodeInterpreter() as sandbox:
-    print(sandbox.id)
-    execution = sandbox.notebook.exec_cell(code)
-
-print(execution.results[0].formats())
-print(len(execution.results))
+with CodeInterpreter(template="code-interpreter-stateful-lab") as sandbox:
+    print(f"https://{sandbox.get_hostname(8888)}/doc/tree/RTC:default.ipynb")
+    sandbox.notebook.exec_cell(code)
+    sandbox.notebook.exec_cell(graph)
+    while True:
+        r = sandbox.notebook.exec_cell(input("code: "))
+        if r.results:
+            print(r.results[0].text)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "e2b-code-interpreter"
-version = "0.0.8a0"
+version = "0.0.8a1"
 description = "E2B Code Interpreter - Stateful code execution"
 authors = ["e2b <hello@e2b.dev>"]
 license = "Apache-2.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "e2b-code-interpreter"
-version = "0.0.7"
+version = "0.0.8a0"
 description = "E2B Code Interpreter - Stateful code execution"
 authors = ["e2b <hello@e2b.dev>"]
 license = "Apache-2.0"

--- a/template/e2b.toml
+++ b/template/e2b.toml
@@ -1,16 +1,16 @@
 # This is a config for E2B sandbox template.
-# You can use 'template_id' (1tsfj5yvigmgc5gmgqz2) or 'template_name (code-interpreter-stateful) from this config to spawn a sandbox:
+# You can use 'template_id' (w9nfeev5mm8a64f8tqw2) or 'template_name (code-interpreter-stateful-lab) from this config to spawn a sandbox:
 
 # Python SDK
 # from e2b import Sandbox
-# sandbox = Sandbox(template='code-interpreter-stateful')
+# sandbox = Sandbox(template='code-interpreter-stateful-lab')
 
 # JS SDK
 # import { Sandbox } from 'e2b'
-# const sandbox = await Sandbox.create({ template: 'code-interpreter-stateful' })
+# const sandbox = await Sandbox.create({ template: 'code-interpreter-stateful-lab' })
 
 memory_mb = 1_024
 start_cmd = "/root/.jupyter/start-up.sh"
 dockerfile = "e2b.Dockerfile"
-template_name = "code-interpreter-stateful"
-template_id = "1tsfj5yvigmgc5gmgqz2"
+template_name = "code-interpreter-stateful-lab"
+template_id = "w9nfeev5mm8a64f8tqw2"

--- a/template/requirements.txt
+++ b/template/requirements.txt
@@ -1,7 +1,8 @@
 # Jupyter server requirements
-jupyter-server==2.13.0
 ipykernel==6.29.3
 ipython==8.22.2
+jupyter-collaboration==3.0.0a2
+jupyterlab==4.2.0
 
 # Other packages
 aiohttp==3.9.3
@@ -18,10 +19,10 @@ opencv-python==4.9.0.80
 openpyxl==3.1.2
 pandas==1.5.3
 plotly==5.19.0
-pytest==8.1.0
+pytest==8.2.0
 python-docx==1.1.0
 pytz==2024.1
-requests==2.26.0
+requests==2.31.0
 scikit-image==0.22.0
 scikit-learn==1.4.1.post1
 scipy==1.12.0


### PR DESCRIPTION
# Description

Save all the execution in jupyter notebook. This allows users to interact with the code executed by LLM, see the history, etc.

## Current limitations
- Only one kernel
- If you execute code in jupyter lab and then in SDK, you have to refresh jupyter lab (it won't refresh the page correctly, it will render as a white page)
    - notebook manipulation isn't solved ideally right now, using ydoc websocket should solve it (jupyter lab also uses it)