### PR TITLE
Add support for additional language runtimes

### DIFF
--- a/js/example.js
+++ b/js/example.js
@@ -3,9 +3,11 @@ const dotenv = require('dotenv')
 dotenv.config()
 
 async function main() {
-  const sandbox = await CodeInterpreter.create()
-  const r = await sandbox.notebook.execCell('x = 1; x')
-  console.log(r)
+const sandbox = await CodeInterpreter.create()
+const jsID = await sandbox.notebook.createKernel({kernelName: "javascript"})
+const execution = await sandbox.notebook.execCell("console.log('Hello World!')", { kernelID: jsID })
+console.log(execution)
+
 }
 
 main().catch(console.error)

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2b/code-interpreter",
-  "version": "0.0.8",
+  "version": "0.0.9-multikernel-code-interpreterer.0",
   "description": "E2B Code Interpreter - Stateful code execution",
   "homepage": "https://e2b.dev",
   "license": "MIT",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2b/code-interpreter",
-  "version": "0.0.9-multikernel-code-interpreterer.0",
+  "version": "0.0.9-multikernel-code-interpreterer.1",
   "description": "E2B Code Interpreter - Stateful code execution",
   "homepage": "https://e2b.dev",
   "license": "MIT",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2b/code-interpreter",
-  "version": "0.0.8-multikernel-code-interpreterer.0",
+  "version": "0.0.8-multikernel-code-interpreterer.1",
   "description": "E2B Code Interpreter - Stateful code execution",
   "homepage": "https://e2b.dev",
   "license": "MIT",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2b/code-interpreter",
-  "version": "0.0.8",
+  "version": "0.0.8-multikernel-code-interpreterer.0",
   "description": "E2B Code Interpreter - Stateful code execution",
   "homepage": "https://e2b.dev",
   "license": "MIT",

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2b/code-interpreter",
-  "version": "0.0.8-multikernel-code-interpreterer.1",
+  "version": "0.0.8",
   "description": "E2B Code Interpreter - Stateful code execution",
   "homepage": "https://e2b.dev",
   "license": "MIT",

--- a/js/src/code-interpreter.ts
+++ b/js/src/code-interpreter.ts
@@ -10,7 +10,7 @@ interface Kernels {
  * E2B code interpreter sandbox extension.
  */
 export class CodeInterpreter extends Sandbox {
-  private static template = 'code-interpreter-stateful'
+  private static template = 'code-interpreter-multikernel'
 
   readonly notebook = new JupyterExtension(this)
 

--- a/js/src/code-interpreter.ts
+++ b/js/src/code-interpreter.ts
@@ -136,16 +136,16 @@ export class JupyterExtension {
    * Once the kernel is created, this method establishes a WebSocket connection to the new kernel for
    * real-time communication.
    *
-   * @param cwd Sets the current working directory where the kernel should start. Defaults to "/home/user".
-   * @param kernelName The name of the kernel to create, useful if you have multiple kernel types. If not provided, the default kernel will be used.
    * @returns A promise that resolves with the ID of the newly created kernel.
    * @throws {Error} Throws an error if the kernel creation fails.
+   * @param opts The options to configure the new kernel.
+   * @param opts.cwd The working directory for the new kernel.
+   * @param opts.kernelName The name of the kernel to create.
    */
-  async createKernel(
-    cwd: string = '/home/user',
-    kernelName?: string
-  ): Promise<string> {
-    kernelName = kernelName || 'python3'
+  async createKernel(opts: { cwd?: string, kernelName?: string } = {
+                       cwd:'/home/user',
+}): Promise<string> {
+    const kernelName = opts.kernelName || 'python3'
 
 
     const data = { path: id(16), kernel: {name: kernelName}, type: "notebook", name: id(16) }
@@ -175,7 +175,7 @@ export class JupyterExtension {
       )}/api/sessions/${sessionID}`,
       {
         method: 'PATCH',
-        body: JSON.stringify({path: cwd})
+        body: JSON.stringify({path: opts.cwd})
       }
     )
 

--- a/python/e2b_code_interpreter/main.py
+++ b/python/e2b_code_interpreter/main.py
@@ -23,7 +23,7 @@ class CodeInterpreter(Sandbox):
     E2B code interpreter sandbox extension.
     """
 
-    template = "code-interpreter-stateful"
+    template = "code-interpreter-multikernel"
 
     def __init__(
         self,

--- a/python/example.py
+++ b/python/example.py
@@ -16,6 +16,11 @@ js_code = """
 console.log("Hello World");
 """
 
+r_code = """
+x <- 13
+x
+"""
+
 with CodeInterpreter() as sandbox:
     print(sandbox.id)
 
@@ -32,6 +37,13 @@ with CodeInterpreter() as sandbox:
 
     java_id = sandbox.notebook.create_kernel(kernel_name="java")
     execution = sandbox.notebook.exec_cell(java_code, kernel_id=java_id)
+    print(execution)
+    print(execution.logs)
+    print(len(execution.results))
+
+
+    r_id = sandbox.notebook.create_kernel(kernel_name="R")
+    execution = sandbox.notebook.exec_cell(r_code, kernel_id=r_id)
     print(execution)
     print(execution.logs)
     print(len(execution.results))

--- a/python/example.py
+++ b/python/example.py
@@ -5,27 +5,14 @@ load_dotenv()
 
 
 code = """
-import matplotlib.pyplot as plt
-import numpy as np
-
-x = np.linspace(0, 20, 100)
-y = np.sin(x)
-
-plt.plot(x, y)
-plt.show()
-
-x = np.linspace(0, 10, 100)
-
-plt.plot(x, y)
-plt.show()
-
-import pandas
-pandas.DataFrame({"a": [1, 2, 3]})
+(int) eval("1 + 1") + 3
 """
 
-with CodeInterpreter() as sandbox:
+with CodeInterpreter(domain="e2b-api.com") as sandbox:
     print(sandbox.id)
-    execution = sandbox.notebook.exec_cell(code)
+    k_id = sandbox.notebook.create_kernel(kernel_name="java")
+    execution = sandbox.notebook.exec_cell(code, kernel_id=k_id)
 
-print(execution.results[0].formats())
+print(execution)
+print(execution.logs)
 print(len(execution.results))

--- a/python/example.py
+++ b/python/example.py
@@ -41,8 +41,7 @@ with CodeInterpreter() as sandbox:
     print(execution.logs)
     print(len(execution.results))
 
-
-    r_id = sandbox.notebook.create_kernel(kernel_name="R")
+    r_id = sandbox.notebook.create_kernel(kernel_name="r")
     execution = sandbox.notebook.exec_cell(r_code, kernel_id=r_id)
     print(execution)
     print(execution.logs)

--- a/python/example.py
+++ b/python/example.py
@@ -3,16 +3,36 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+python_code = """
+k = 1
+k
+"""
 
-code = """
+java_code = """
 (int) eval("1 + 1") + 3
 """
 
-with CodeInterpreter(domain="e2b-api.com") as sandbox:
-    print(sandbox.id)
-    k_id = sandbox.notebook.create_kernel(kernel_name="java")
-    execution = sandbox.notebook.exec_cell(code, kernel_id=k_id)
+js_code = """
+console.log("Hello World");
+"""
 
-print(execution)
-print(execution.logs)
-print(len(execution.results))
+with CodeInterpreter() as sandbox:
+    print(sandbox.id)
+
+    execution = sandbox.notebook.exec_cell(python_code)
+    print(execution)
+    print(execution.logs)
+    print(len(execution.results))
+
+    js_id = sandbox.notebook.create_kernel(kernel_name="javascript")
+    execution = sandbox.notebook.exec_cell(js_code, kernel_id=js_id)
+    print(execution)
+    print(execution.logs)
+    print(len(execution.results))
+
+    java_id = sandbox.notebook.create_kernel(kernel_name="java")
+    execution = sandbox.notebook.exec_cell(java_code, kernel_id=java_id)
+    print(execution)
+    print(execution.logs)
+    print(len(execution.results))
+

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "e2b-code-interpreter"
-version = "0.0.9"
+version = "0.0.9a0"
 description = "E2B Code Interpreter - Stateful code execution"
 authors = ["e2b <hello@e2b.dev>"]
 license = "Apache-2.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "e2b-code-interpreter"
-version = "0.0.9a0"
+version = "0.0.9a1"
 description = "E2B Code Interpreter - Stateful code execution"
 authors = ["e2b <hello@e2b.dev>"]
 license = "Apache-2.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "e2b-code-interpreter"
-version = "0.0.9a1"
+version = "0.0.9"
 description = "E2B Code Interpreter - Stateful code execution"
 authors = ["e2b <hello@e2b.dev>"]
 license = "Apache-2.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "e2b-code-interpreter"
-version = "0.0.9"
+version = "0.0.10a0"
 description = "E2B Code Interpreter - Stateful code execution"
 authors = ["e2b <hello@e2b.dev>"]
 license = "Apache-2.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "e2b-code-interpreter"
-version = "0.0.10a0"
+version = "0.0.10a1"
 description = "E2B Code Interpreter - Stateful code execution"
 authors = ["e2b <hello@e2b.dev>"]
 license = "Apache-2.0"

--- a/template/e2b.Dockerfile
+++ b/template/e2b.Dockerfile
@@ -24,10 +24,16 @@ COPY ipython_kernel_config.py $IPYTHON_CONFIG_PATH/profile_default/
 COPY ./start-up.sh $JUPYTER_CONFIG_PATH/
 RUN chmod +x $JUPYTER_CONFIG_PATH/start-up.sh
 
-
+# Java Kernel
 RUN wget https://github.com/SpencerPark/IJava/releases/download/v1.3.0/ijava-1.3.0.zip && \
     unzip ijava-1.3.0.zip && \
     python install.py --sys-prefix
 
+# Javascript Kernel
 RUN npm install -g --unsafe-perm ijavascript
 RUN ijsinstall --install=global
+
+# R Kernel
+RUN apt-get update && apt-get install -y r-base
+RUN R -e "install.packages('IRkernel')"
+RUN R -e "IRkernel::installspec(user = FALSE, name = 'r', displayname = 'R')"

--- a/template/e2b.Dockerfile
+++ b/template/e2b.Dockerfile
@@ -5,7 +5,7 @@ COPY --from=eclipse-temurin:11-jdk $JAVA_HOME $JAVA_HOME
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
-  build-essential curl git util-linux jq
+  build-essential curl git util-linux jq nodejs npm
 
 ENV PIP_DEFAULT_TIMEOUT=100 \
   PIP_DISABLE_PIP_VERSION_CHECK=1 \
@@ -28,3 +28,6 @@ RUN chmod +x $JUPYTER_CONFIG_PATH/start-up.sh
 RUN wget https://github.com/SpencerPark/IJava/releases/download/v1.3.0/ijava-1.3.0.zip && \
     unzip ijava-1.3.0.zip && \
     python install.py --sys-prefix
+
+RUN npm install -g --unsafe-perm ijavascript
+RUN ijsinstall --install=global

--- a/template/e2b.Dockerfile
+++ b/template/e2b.Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.10
 
+ENV JAVA_HOME=/opt/java/openjdk
+COPY --from=eclipse-temurin:11-jdk $JAVA_HOME $JAVA_HOME
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
   build-essential curl git util-linux jq
 
@@ -19,3 +23,8 @@ COPY ipython_kernel_config.py $IPYTHON_CONFIG_PATH/profile_default/
 
 COPY ./start-up.sh $JUPYTER_CONFIG_PATH/
 RUN chmod +x $JUPYTER_CONFIG_PATH/start-up.sh
+
+
+RUN wget https://github.com/SpencerPark/IJava/releases/download/v1.3.0/ijava-1.3.0.zip && \
+    unzip ijava-1.3.0.zip && \
+    python install.py --sys-prefix

--- a/template/e2b.Dockerfile
+++ b/template/e2b.Dockerfile
@@ -37,3 +37,7 @@ RUN ijsinstall --install=global
 RUN apt-get update && apt-get install -y r-base
 RUN R -e "install.packages('IRkernel')"
 RUN R -e "IRkernel::installspec(user = FALSE, name = 'r', displayname = 'R')"
+
+# Bash Kernel
+RUN pip install bash_kernel
+RUN python -m bash_kernel.install

--- a/template/e2b.toml
+++ b/template/e2b.toml
@@ -1,5 +1,5 @@
 # This is a config for E2B sandbox template.
-# You can use 'template_id' (1tsfj5yvigmgc5gmgqz2) or 'template_name (code-interpreter-stateful) from this config to spawn a sandbox:
+# You can use 'template_id' (izh2hyxizx0qanbiijvn) or 'template_name (code-interpreter-stateful) from this config to spawn a sandbox:
 
 # Python SDK
 # from e2b import Sandbox
@@ -9,8 +9,7 @@
 # import { Sandbox } from 'e2b'
 # const sandbox = await Sandbox.create({ template: 'code-interpreter-stateful' })
 
-memory_mb = 1_024
 start_cmd = "/root/.jupyter/start-up.sh"
 dockerfile = "e2b.Dockerfile"
 template_name = "code-interpreter-stateful"
-template_id = "1tsfj5yvigmgc5gmgqz2"
+template_id = "izh2hyxizx0qanbiijvn"

--- a/template/e2b.toml
+++ b/template/e2b.toml
@@ -1,15 +1,16 @@
 # This is a config for E2B sandbox template.
-# You can use 'template_id' (izh2hyxizx0qanbiijvn) or 'template_name (code-interpreter-stateful) from this config to spawn a sandbox:
+# You can use 'template_id' (g8fvsnfpjr2truanf91h) or 'template_name (code-interpreter-multikernel) from this config to spawn a sandbox:
 
 # Python SDK
 # from e2b import Sandbox
-# sandbox = Sandbox(template='code-interpreter-stateful')
+# sandbox = Sandbox(template='code-interpreter-multikernel')
 
 # JS SDK
 # import { Sandbox } from 'e2b'
-# const sandbox = await Sandbox.create({ template: 'code-interpreter-stateful' })
+# const sandbox = await Sandbox.create({ template: 'code-interpreter-multikernel' })
 
+memory_mb = 1_024
 start_cmd = "/root/.jupyter/start-up.sh"
 dockerfile = "e2b.Dockerfile"
-template_name = "code-interpreter-stateful"
-template_id = "izh2hyxizx0qanbiijvn"
+template_name = "code-interpreter-multikernel"
+template_id = "g8fvsnfpjr2truanf91h"

--- a/template/start-up.sh
+++ b/template/start-up.sh
@@ -29,6 +29,8 @@ function start_jupyter_server() {
 	echo "Jupyter Server started"
 }
 
+export PATH="/opt/java/openjdk/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 echo "Starting Jupyter Server..."
 start_jupyter_server &
 jupyter server --IdentityProvider.token=""


### PR DESCRIPTION
# Support for multiple languages

## Description

This feature adds following kernels (= language runtimes) to the Code Interpreter SDK (besides the default Python):
- R
- JavaScript
- Java
- Bash

## Installation

You need to install a pre-release version of the SDK

**Python**
```python
pip install e2b-code-interpreter==0.0.10a0
```

**JavaScript/TypeScript**
```js
npm i @e2b/code-interpreter@0.0.9-multikernel-code-interpreterer.0
```


## Usage
You can use multiple kernels in a single code interpreter sandbox.

**Python**
```python
with CodeInterpreter() as sandbox:
    # 1. Set JS kernel - available kernel names: 'r', 'javascript', 'java', 'bash'
    js_id = sandbox.notebook.create_kernel(kernel_name="javascript")
    # 2. Run JS code inside code interpreter!
    execution = sandbox.notebook.exec_cell("console.log('Hello World!')", kernel_id=js_id)
    print(execution)
    # 3. Use Python again
    sandbox.notebook.exec_cell("print('Hello World!')")
```

**JavaScript/TypeScript**
```js
const sandbox = await CodeInterpreter.create()

// 1. Set JS kernel - available kernel names: 'r', 'javascript', 'java', 'bash'
const jsID = await sandbox.notebook.createKernel({ kernelName: 'javascript' })
// 2. Run JS code inside code interpreter!
const execution = await sandbox.notebook.execCell("console.log('Hello World!')", { kernelID: jsID })
console.log(execution)
// 3. Use Python again
await sandbox.notebook.execCell('print("Hello World!")')

await sandbox.close()
```

## Customization

If you would like to preinstall some packages or add your own languages, you can do it by copying all files except `e2b.toml` from [the template folder on this branch](https://github.com/e2b-dev/code-interpreter/tree/multikernel-code-interpreterer/template) to the directory where is your `e2b.Dockerfile`. You can freely edit the files and built your own template by running 
```bash
e2b template build -c "/home/user/.jupyter/start-up.sh"
```
You can find more about custom templates in [here](https://e2b.dev/docs/sandbox/templates/overview).
In the production release, this process will be significantly simplified.