### PR TITLE
Fix bug in e2b incompatibility

### DIFF
--- a/.changeset/silver-years-bake.md
+++ b/.changeset/silver-years-bake.md
@@ -1,0 +1,5 @@
+---
+'@e2b/code-interpreter-python': patch
+---
+
+Remove bug in init method

--- a/python/e2b_code_interpreter/code_interpreter_async.py
+++ b/python/e2b_code_interpreter/code_interpreter_async.py
@@ -57,9 +57,6 @@ class AsyncSandbox(BaseAsyncSandbox):
 
     default_template = DEFAULT_TEMPLATE
 
-    def __init__(self, sandbox_id: str, connection_config: ConnectionConfig):
-        super().__init__(sandbox_id=sandbox_id, connection_config=connection_config)
-
     @property
     def _jupyter_url(self) -> str:
         return f"{'http' if self.connection_config.debug else 'https'}://{self.get_host(JUPYTER_PORT)}"


### PR DESCRIPTION
# Description

There was a new parameter inside init method, which caused TypeErrors if you had `e2b` version `1.0.6`