### PR TITLE
Fix SDK reference generation 

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -42,8 +42,8 @@
     "knip": "^5.25.1",
     "npm-check-updates": "^17.1.14",
     "tsup": "^8.3.6",
-    "typedoc": "^0.27.6",
-    "typedoc-plugin-markdown": "^4.2.7",
+    "typedoc": "0.26.8",
+    "typedoc-plugin-markdown": "4.2.7",
     "typescript": "^5.5.3",
     "vitest": "^3.0.5"
   },


### PR DESCRIPTION
Pin typdoc to non-breaking versions in js-sdk