### PR TITLE
Update Ubuntu base image to 22.04

### DIFF
--- a/.github/workflows/charts_tests.yml
+++ b/.github/workflows/charts_tests.yml
@@ -12,7 +12,7 @@ jobs:
       run:
         working-directory: ./chart_data_extractor
     name: Build and test Chart Data Extractor
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/js_tests.yml
+++ b/.github/workflows/js_tests.yml
@@ -15,7 +15,7 @@ jobs:
       run:
         working-directory: ./js
     name: Build and test SDK
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -15,7 +15,7 @@ jobs:
       run:
         working-directory: ./python
     name: Build and test SDK
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
# Description

There is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
