### PR TITLE
Show SDK ref dir only when it exists in GH release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,7 +321,12 @@ jobs:
         run: pnpm run --recursive generate-ref
       
       - name: Show docs file structure
-        run: tree ./sdk-reference
+        run: |
+          if [ -d "./sdk-reference" ]; then
+            tree ./sdk-reference
+          else
+            echo "sdk-reference directory does not exist"
+          fi
 
       - name: Release new versions
         uses: changesets/action@v1


### PR DESCRIPTION
## Description
To avoid errors like [these](https://github.com/e2b-dev/E2B/actions/runs/14200197836/job/39785152642) where we publish without any sdk ref changes.