### PR TITLE
Configure code interpreter server idle timeout

### DIFF
--- a/.changeset/stale-olives-cover.md
+++ b/.changeset/stale-olives-cover.md
@@ -1,0 +1,5 @@
+---
+'@e2b/code-interpreter-template': patch
+---
+
+Increase keep alive timeout

--- a/template/start-up.sh
+++ b/template/start-up.sh
@@ -26,7 +26,7 @@ function start_jupyter_server() {
 	sudo echo "${response}" | sudo tee /root/.jupyter/.session_info >/dev/null
 
 	cd /root/.server/
-	/root/.server/.venv/bin/uvicorn main:app --host 0.0.0.0 --port 49999 --workers 1 --no-access-log --no-use-colors
+	/root/.server/.venv/bin/uvicorn main:app --host 0.0.0.0 --port 49999 --workers 1 --no-access-log --no-use-colors --timeout-keep-alive 640 --timeout 84600
 }
 
 echo "Starting Code Interpreter server..."

--- a/template/start-up.sh
+++ b/template/start-up.sh
@@ -26,7 +26,7 @@ function start_jupyter_server() {
 	sudo echo "${response}" | sudo tee /root/.jupyter/.session_info >/dev/null
 
 	cd /root/.server/
-	/root/.server/.venv/bin/uvicorn main:app --host 0.0.0.0 --port 49999 --workers 1 --no-access-log --no-use-colors --timeout-keep-alive 640 --timeout 84600
+	/root/.server/.venv/bin/uvicorn main:app --host 0.0.0.0 --port 49999 --workers 1 --no-access-log --no-use-colors --timeout-keep-alive 640
 }
 
 echo "Starting Code Interpreter server..."


### PR DESCRIPTION
Configure idle timeout to respect the timeout of proxies and LB (LB 610s -> client-proxy 620s -> orchestrator-proxy 630s).