### PR TITLE
Python 3.12 support + deps bump

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.14
+FROM python:3.13
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
   build-essential curl git util-linux jq sudo fonts-noto-cjk

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13
+FROM python:3.12
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
   build-essential curl git util-linux jq sudo fonts-noto-cjk

--- a/template/requirements.txt
+++ b/template/requirements.txt
@@ -1,42 +1,43 @@
 # Jupyter server requirements
-jupyter-server==2.13.0
-ipykernel==6.29.3
-ipython==8.22.2
+jupyter-server==2.16.0
+ipykernel==6.29.5
+ipython==9.2.0
 
-orjson==3.9.15
-pandas==1.5.3
-matplotlib==3.9.2
-pillow==10.3.0
+orjson==3.10.18
+pandas==2.2.3
+matplotlib==3.10.3
+pillow==11.2.1
 
 # Latest version for
 e2b_charts
 
 # Other packages
-aiohttp==3.10.11
-beautifulsoup4==4.12.3
-bokeh==3.3.4
-gensim==4.3.2
-imageio==2.34.0
-joblib==1.3.2
-librosa==0.10.1
-nltk==3.9
-numpy==1.26.4
-opencv-python==4.9.0.80
-openpyxl==3.1.2
-plotly==5.19.0
-pytest==8.1.0
-python-docx==1.1.0
-pytz==2024.1
-requests==2.32.2
-scikit-image==0.22.0
-scikit-learn==1.5.0
-scipy==1.12.0
+aiohttp==3.11.18
+beautifulsoup4==4.13.4
+bokeh==3.7.3
+# gensim==4.3.3
+imageio==2.37.0
+joblib==1.5.0
+librosa==0.11.0
+nltk==3.9.1
+numpy==2.2.5
+numba==0.61.2
+opencv-python==4.11.0.86
+openpyxl==3.1.5
+plotly==6.0.1
+pytest==8.3.5
+python-docx==1.1.2
+pytz==2025.2
+requests==2.32.3
+scikit-image==0.25.2
+scikit-learn==1.6.1
+scipy==1.15.3
 seaborn==0.13.2
-soundfile==0.12.1
-spacy==3.7.4
-textblob==0.18.0
+soundfile==0.13.1
+# spacy==3.8.2
+textblob==0.19.0
 tornado==6.4.2
-urllib3==1.26.19
-xarray==2024.2.0
+urllib3==2.4.0
+xarray==2025.4.0
 xlrd==2.0.1
-sympy==1.12
+sympy==1.14.0

--- a/template/requirements.txt
+++ b/template/requirements.txt
@@ -15,12 +15,12 @@ e2b_charts
 aiohttp==3.11.18
 beautifulsoup4==4.13.4
 bokeh==3.7.3
-# gensim==4.3.3
+gensim==4.3.3 # unmaintained, blocking numpy and scipy bump
 imageio==2.37.0
 joblib==1.5.0
 librosa==0.11.0
 nltk==3.9.1
-numpy==2.2.5
+numpy==1.26.4 # bump blocked by gensim
 numba==0.61.2
 opencv-python==4.11.0.86
 openpyxl==3.1.5
@@ -31,10 +31,10 @@ pytz==2025.2
 requests==2.32.3
 scikit-image==0.25.2
 scikit-learn==1.6.1
-scipy==1.15.3
+scipy==1.13.1 # bump blocked by gensim
 seaborn==0.13.2
 soundfile==0.13.1
-# spacy==3.8.2
+spacy==3.8.2 # doesn't work on 3.13.x
 textblob==0.19.0
 tornado==6.4.2
 urllib3==2.4.0

--- a/template/test.Dockerfile
+++ b/template/test.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.14
+FROM python:3.13
 
 ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:11-jdk $JAVA_HOME $JAVA_HOME

--- a/template/test.Dockerfile
+++ b/template/test.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13
+FROM python:3.12
 
 ENV JAVA_HOME=/opt/java/openjdk
 COPY --from=eclipse-temurin:11-jdk $JAVA_HOME $JAVA_HOME


### PR DESCRIPTION
Changelog:

- resolves #70
- updates base images to Python 3.12
- dependency bump in requirements.txt
- some packages, in particular gensim depend on older versions of numpy, scipy thus cannot be bumped (note added in code)

Note: I have tried upgrading to 3.13, but some popular packages, particularly spacy don't work, holding off the 3.13 as it could be causing similar issues to our customers.