### PR TITLE
Bump E2B dependency

### DIFF
--- a/.changeset/early-crabs-sort.md
+++ b/.changeset/early-crabs-sort.md
@@ -1,5 +1,0 @@
----
-'@e2b/code-interpreter-template': patch
----
-
-added kaleido that is no longer direct dependency of plotly

--- a/.changeset/weak-ducks-clean.md
+++ b/.changeset/weak-ducks-clean.md
@@ -1,0 +1,5 @@
+---
+'@e2b/code-interpreter-python': patch
+---
+
+updated e2b version

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -239,7 +239,7 @@ description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 groups = ["dev"]
-markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
+markers = "sys_platform == \"win32\" or platform_system == \"Windows\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -363,14 +363,14 @@ test = ["black", "pytest"]
 
 [[package]]
 name = "e2b"
-version = "1.4.0"
+version = "1.5.4"
 description = "E2B SDK that give agents cloud environments"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
 files = [
-    {file = "e2b-1.4.0-py3-none-any.whl", hash = "sha256:a489015ece78ecabfdc281463ed495b6e4adf8c66278bb7312069d8ded21ab52"},
-    {file = "e2b-1.4.0.tar.gz", hash = "sha256:6a4596d4f91df32340bdbfac429591980a8dedd7ac509aae73f1bbc128175245"},
+    {file = "e2b-1.5.4-py3-none-any.whl", hash = "sha256:9c8d22f9203311dff890e037823596daaba3d793300238117f2efc5426888f2c"},
+    {file = "e2b-1.5.4.tar.gz", hash = "sha256:49f1c115d0198244beef5854d19cc857fda9382e205f137b98d3dae0e7e0b2d2"},
 ]
 
 [package.dependencies]
@@ -1193,4 +1193,4 @@ tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "e2b926469f1010c15bc330c9866099bbfad8dbcdc157d5e5174a07886945b3bf"
+content-hash = "166eb5f8bc1132d916fa088a8b99eb4611498215fcf720e5abe4681b2ab71958"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -14,7 +14,7 @@ python = "^3.9"
 
 httpx = ">=0.20.0, <1.0.0"
 attrs = ">=21.3.0"
-e2b = "^1.4.0"
+e2b = "^1.5.4"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
- fixes RuntimeError: Attempted to access 'response.content' on a streaming response. Call 'response.read()' first.