### PR TITLE
Pre-load JavaScript kernel into memory for faster JS startup

### DIFF
--- a/template/server/main.py
+++ b/template/server/main.py
@@ -36,9 +36,12 @@ async def lifespan(app: FastAPI):
     client = httpx.AsyncClient()
 
     try:
-        default_context = await create_context(client, websockets, "python", "/home/user")
-        default_websockets["python"] = default_context.id
-        websockets["default"] = websockets[default_context.id]
+        python_context = await create_context(client, websockets, "python", "/home/user")
+        default_websockets["python"] = python_context.id
+        websockets["default"] = websockets[python_context.id]
+
+        javascript_context = await create_context(client, websockets, "javascript", "/home/user")
+        default_websockets["javascript"] = javascript_context.id
 
         logger.info("Connected to default runtime")
         yield


### PR DESCRIPTION
### Benchmarks

**Execution time**

Before:
Python kernel time taken: 64.61 milliseconds
JavaScript kernel time taken: **256.47** milliseconds


After:
Python kernel time taken: 64.32 milliseconds
JavaScript kernel time taken: **67.80** milliseconds

**Memory usage**

Before/after loading JavaScript kernel into memory (idle)

<img width="804" height="164" alt="Screenshot 2025-08-20 at 10 40 11" src="https://github.com/user-attachments/assets/d5db2379-2ee0-4480-847a-c64f4f2511f6" />

