### PR TITLE
Update R kernel installation, remove dependency on r studio CDN

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
-  build-essential curl git util-linux jq sudo fonts-noto-cjk
+  build-essential curl git util-linux jq sudo fonts-noto-cjk r-base
 
 # Install Node.js 20.x from NodeSource
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
@@ -23,7 +23,6 @@ COPY ./requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt && ipython kernel install --name "python3" --user
 
 # R Kernel
-RUN curl -O https://cdn.rstudio.com/r/debian-12/pkgs/r-${R_VERSION}_1_amd64.deb && sudo apt-get update && sudo apt-get install -y ./r-${R_VERSION}_1_amd64.deb && ln -s ${R_HOME}/bin/R /usr/bin/R
 RUN R -e "install.packages('IRkernel', repos='https://cloud.r-project.org')"
 RUN R -e "IRkernel::installspec(user = FALSE, name = 'r', displayname = 'R')"
 


### PR DESCRIPTION
Some unexpected changed on the CDN broke R installation

version before:

4.4.2

version after

4.5.0