### PR TITLE
Fix performance regression when setting env vars on first execution

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -17,7 +17,7 @@ def template():
 
 @pytest.fixture()
 def sandbox(template, debug):
-    sandbox = Sandbox(template, timeout=timeout)
+    sandbox = Sandbox(template, timeout=timeout, debug=debug)
 
     try:
         yield sandbox
@@ -33,7 +33,7 @@ def sandbox(template, debug):
 
 @pytest_asyncio.fixture
 async def async_sandbox(template, debug):
-    async_sandbox = await AsyncSandbox.create(template, timeout=timeout)
+    async_sandbox = await AsyncSandbox.create(template, timeout=timeout, debug=debug)
 
     try:
         yield async_sandbox

--- a/template/server/main.py
+++ b/template/server/main.py
@@ -105,11 +105,6 @@ async def post_execute(request: ExecutionRequest):
             status_code=404,
         )
 
-    # set global env vars if not set on first execution
-    if not ws.global_env_vars:
-        ws.global_env_vars = await get_envs()
-        await ws.set_env_vars(ws.global_env_vars)
-
     return StreamingListJsonResponse(
         ws.execute(
             request.code,

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -49,7 +49,6 @@ class ContextWebSocket:
     _ws: Optional[WebSocketClientProtocol] = None
     _receive_task: Optional[asyncio.Task] = None
     _global_env_vars: Optional[Dict[StrictStr, str]] = None
-    _global_env_vars_set = False
     _cleanup_task: Optional[asyncio.Task] = None
 
     def __init__(
@@ -301,20 +300,19 @@ class ContextWebSocket:
             
             # Build the complete code snippet with env vars
             complete_code = code
-            env_var_snippets = []
+            
+            global_env_vars_snippet = ""
+            env_vars_snippet = ""
 
             if self._global_env_vars is None:
                 self._global_env_vars = await get_envs()
-
-            if not self._global_env_vars_set:
-                env_var_snippets.append(self._set_env_vars_code(self._global_env_vars))
-                self._global_env_vars_set = True
+                global_env_vars_snippet = self._set_env_vars_code(self._global_env_vars)
             
             if env_vars:
-                env_var_snippets.append(self._set_env_vars_code(env_vars))
+                env_vars_snippet = self._set_env_vars_code(env_vars)
 
-            if env_var_snippets:
-                indented_env_code = self._indent_code_with_level("\n".join(env_var_snippets), code_indent)
+            if global_env_vars_snippet or env_vars_snippet:
+                indented_env_code = self._indent_code_with_level(f"{global_env_vars_snippet}\n{env_vars_snippet}", code_indent)
                 complete_code = f"{indented_env_code}\n{complete_code}"
 
             logger.info(f"Sending code for the execution ({message_id}): {complete_code}")

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -221,9 +221,6 @@ class ContextWebSocket:
                         logger.error(f"Error during env var cleanup: {item}")
         finally:
             del self._executions[message_id]
-            # Clear the task reference when cleanup is complete
-            if self._cleanup_task and self._cleanup_task.done():
-                self._cleanup_task = None
 
     async def _wait_for_result(self, message_id: str):
         queue = self._executions[message_id].queue

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -302,23 +302,21 @@ class ContextWebSocket:
             
             # Build the complete code snippet with env vars
             complete_code = code
+            env_var_snippets = []
 
             if not self._global_env_vars:
                 self._global_env_vars = await get_envs()
 
             if not self._global_env_vars_set and self._global_env_vars:
-                env_setup_code = self._set_env_vars_code(self._global_env_vars)
-                if env_setup_code:
-                    indented_env_code = self._indent_code_with_level(env_setup_code, code_indent)
-                    complete_code = f"{indented_env_code}\n{complete_code}"
+                env_var_snippets.append(self._set_env_vars_code(self._global_env_vars))
                 self._global_env_vars_set = True
             
             if env_vars:
-                # Add env var setup at the beginning
-                env_setup_code = self._set_env_vars_code(env_vars)
-                if env_setup_code:
-                    indented_env_code = self._indent_code_with_level(env_setup_code, code_indent)
-                    complete_code = f"{indented_env_code}\n{complete_code}"
+                env_var_snippets.append(self._set_env_vars_code(env_vars))
+
+            if env_var_snippets:
+                indented_env_code = self._indent_code_with_level("\n".join(env_var_snippets), code_indent)
+                complete_code = f"{indented_env_code}\n{complete_code}"
 
             logger.info(f"Sending code for the execution ({message_id}): {complete_code}")
             request = self._get_execute_request(message_id, complete_code, False)

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -201,6 +201,8 @@ class ContextWebSocket:
         for line in lines:
             if line.strip():  # Non-empty lines
                 indented_lines.append(indent_level + line)
+            else:
+                indented_lines.append(line)
         
         return '\n'.join(indented_lines)
 
@@ -301,10 +303,10 @@ class ContextWebSocket:
             complete_code = code
             env_var_snippets = []
 
-            if not self._global_env_vars:
+            if self._global_env_vars is None:
                 self._global_env_vars = await get_envs()
 
-            if not self._global_env_vars_set and self._global_env_vars:
+            if not self._global_env_vars_set:
                 env_var_snippets.append(self._set_env_vars_code(self._global_env_vars))
                 self._global_env_vars_set = True
             

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -281,8 +281,6 @@ class ContextWebSocket:
         env_vars: Dict[StrictStr, str] = None,
     ):
         message_id = str(uuid.uuid4())
-        logger.debug(f"Sending code for the execution ({message_id}): {code}")
-
         self._executions[message_id] = Execution()
 
         if self._ws is None:
@@ -313,7 +311,7 @@ class ContextWebSocket:
                 if env_setup_code:
                     indented_env_code = self._indent_code_with_level(env_setup_code, code_indent)
                     complete_code = f"{indented_env_code}\n{complete_code}"
-                self.global_env_vars_set = True
+                self._global_env_vars_set = True
             
             if env_vars:
                 # Add env var setup at the beginning
@@ -322,7 +320,7 @@ class ContextWebSocket:
                     indented_env_code = self._indent_code_with_level(env_setup_code, code_indent)
                     complete_code = f"{indented_env_code}\n{complete_code}"
 
-            logger.info(f"Executing complete code: {complete_code}")
+            logger.info(f"Sending code for the execution ({message_id}): {complete_code}")
             request = self._get_execute_request(message_id, complete_code, False)
 
             # Send the code for execution

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -265,7 +265,7 @@ class ContextWebSocket:
                 self.global_env_vars = await get_envs()
 
             if not self.global_env_vars_set and self.global_env_vars:
-                complete_code = self._set_env_vars_code(self.global_env_vars)
+                complete_code = f"{self._set_env_vars_code(self.global_env_vars)}\n{complete_code}"
                 self.global_env_vars_set = True
             
             if env_vars:

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -48,8 +48,8 @@ class Execution:
 class ContextWebSocket:
     _ws: Optional[WebSocketClientProtocol] = None
     _receive_task: Optional[asyncio.Task] = None
-    global_env_vars: Optional[Dict[StrictStr, str]] = None
-    global_env_vars_set = False
+    _global_env_vars: Optional[Dict[StrictStr, str]] = None
+    _global_env_vars_set = False
     _cleanup_task: Optional[asyncio.Task] = None
 
     def __init__(
@@ -165,9 +165,9 @@ class ContextWebSocket:
         
         for key in env_vars:
             # Check if this var exists in global env vars
-            if self.global_env_vars and key in self.global_env_vars:
+            if self._global_env_vars and key in self._global_env_vars:
                 # Reset to global value
-                value = self.global_env_vars[key]
+                value = self._global_env_vars[key]
                 command = self._set_env_var_snippet(key, value)
             else:
                 # Remove the variable
@@ -305,11 +305,11 @@ class ContextWebSocket:
             # Build the complete code snippet with env vars
             complete_code = code
 
-            if not self.global_env_vars:
-                self.global_env_vars = await get_envs()
+            if not self._global_env_vars:
+                self._global_env_vars = await get_envs()
 
-            if not self.global_env_vars_set and self.global_env_vars:
-                env_setup_code = self._set_env_vars_code(self.global_env_vars)
+            if not self._global_env_vars_set and self._global_env_vars:
+                env_setup_code = self._set_env_vars_code(self._global_env_vars)
                 if env_setup_code:
                     indented_env_code = self._indent_code_with_level(env_setup_code, code_indent)
                     complete_code = f"{indented_env_code}\n{complete_code}"


### PR DESCRIPTION
Changes

- Setting env vars now appends a generated code snippet to the user code with no extra request to Jupyter.
- Resetting env vars happens in a separate request in background after response so that the return of the last cell stays unmodified.
- Because resetting happens in background but the new execution will wait until the previous cleanup task has been completed (to ensure correctness), fast subsequent requests might get delayed due that reason

Remarks

- I suppose, we can cut even more ms when starting new kernels by making `change_current_directory` append to the user code on first request like the env vars.

### Benchmark

Tested locally in debug mode.

Sample code used:

```py
from e2b_code_interpreter import Sandbox
import time

sbx = Sandbox(debug=True)

# Start time measure
start_time = time.time()
sbx.run_code("os.environ['hello']", envs={"hello": "world"})
end_time = time.time()
print(f"Python kernel time taken: {(end_time - start_time) * 1000:.2f} milliseconds")
```

**Before**

Python kernel time taken: **116.38** milliseconds

**After**

Python kernel time taken: **18.64** milliseconds