### PR TITLE
Handle websocket error gracefully + add retry logic

### DIFF
--- a/.changeset/curly-pumpkins-kick.md
+++ b/.changeset/curly-pumpkins-kick.md
@@ -1,0 +1,5 @@
+---
+'@e2b/code-interpreter-template': patch
+---
+
+Add retry

--- a/.changeset/wicked-mirrors-punch.md
+++ b/.changeset/wicked-mirrors-punch.md
@@ -1,0 +1,5 @@
+---
+'@e2b/code-interpreter-python': patch
+---
+
+Fix issue with secure False

--- a/python/e2b_code_interpreter/code_interpreter_async.py
+++ b/python/e2b_code_interpreter/code_interpreter_async.py
@@ -191,6 +191,10 @@ class AsyncSandbox(BaseAsyncSandbox):
         request_timeout = request_timeout or self.connection_config.request_timeout
         context_id = context.id if context else None
 
+        headers = {}
+        if self._envd_access_token:
+            headers = {"X-Access-Token": self._envd_access_token}
+
         try:
             async with self._client.stream(
                 "POST",
@@ -201,7 +205,7 @@ class AsyncSandbox(BaseAsyncSandbox):
                     "language": language,
                     "env_vars": envs,
                 },
-                headers={"X-Access-Token": self._envd_access_token},
+                headers=headers,
                 timeout=(request_timeout, timeout, request_timeout, request_timeout),
             ) as response:
                 err = await aextract_exception(response)
@@ -249,10 +253,14 @@ class AsyncSandbox(BaseAsyncSandbox):
         if cwd:
             data["cwd"] = cwd
 
+        headers = {}
+        if self._envd_access_token:
+            headers = {"X-Access-Token": self._envd_access_token}
+
         try:
             response = await self._client.post(
                 f"{self._jupyter_url}/contexts",
-                headers={"X-Access-Token": self._envd_access_token},
+                headers=headers,
                 json=data,
                 timeout=request_timeout or self.connection_config.request_timeout,
             )

--- a/python/e2b_code_interpreter/code_interpreter_async.py
+++ b/python/e2b_code_interpreter/code_interpreter_async.py
@@ -193,7 +193,7 @@ class AsyncSandbox(BaseAsyncSandbox):
 
         headers = {}
         if self._envd_access_token:
-            headers = {"X-Access-Token": self._envd_access_token}
+            headers = {"X-Access-Token": self._envd_access_token or ""}
 
         try:
             async with self._client.stream(
@@ -255,7 +255,7 @@ class AsyncSandbox(BaseAsyncSandbox):
 
         headers = {}
         if self._envd_access_token:
-            headers = {"X-Access-Token": self._envd_access_token}
+            headers = {"X-Access-Token": self._envd_access_token or ""}
 
         try:
             response = await self._client.post(

--- a/python/e2b_code_interpreter/code_interpreter_async.py
+++ b/python/e2b_code_interpreter/code_interpreter_async.py
@@ -191,9 +191,9 @@ class AsyncSandbox(BaseAsyncSandbox):
         request_timeout = request_timeout or self.connection_config.request_timeout
         context_id = context.id if context else None
 
-        headers = {}
+        headers: Dict[str, str] = {}
         if self._envd_access_token:
-            headers = {"X-Access-Token": self._envd_access_token or ""}
+            headers = {"X-Access-Token": self._envd_access_token}
 
         try:
             async with self._client.stream(
@@ -253,9 +253,9 @@ class AsyncSandbox(BaseAsyncSandbox):
         if cwd:
             data["cwd"] = cwd
 
-        headers = {}
+        headers: Dict[str, str] = {}
         if self._envd_access_token:
-            headers = {"X-Access-Token": self._envd_access_token or ""}
+            headers = {"X-Access-Token": self._envd_access_token}
 
         try:
             response = await self._client.post(

--- a/python/e2b_code_interpreter/code_interpreter_sync.py
+++ b/python/e2b_code_interpreter/code_interpreter_sync.py
@@ -188,9 +188,9 @@ class Sandbox(BaseSandbox):
         request_timeout = request_timeout or self.connection_config.request_timeout
         context_id = context.id if context else None
 
-        headers = {}
+        headers: Dict[str, str] = {}
         if self._envd_access_token:
-            headers = {"X-Access-Token": self._envd_access_token or ""}
+            headers = {"X-Access-Token": self._envd_access_token}
 
         try:
             with self._client.stream(
@@ -250,9 +250,9 @@ class Sandbox(BaseSandbox):
         if cwd:
             data["cwd"] = cwd
 
-        headers = {}
+        headers: Dict[str, str] = {}
         if self._envd_access_token:
-            headers = {"X-Access-Token": self._envd_access_token or ""}
+            headers = {"X-Access-Token": self._envd_access_token}
 
         try:
             response = self._client.post(

--- a/python/e2b_code_interpreter/code_interpreter_sync.py
+++ b/python/e2b_code_interpreter/code_interpreter_sync.py
@@ -188,6 +188,10 @@ class Sandbox(BaseSandbox):
         request_timeout = request_timeout or self.connection_config.request_timeout
         context_id = context.id if context else None
 
+        headers = {}
+        if self._envd_access_token:
+            headers = {"X-Access-Token": self._envd_access_token or ""}
+
         try:
             with self._client.stream(
                 "POST",
@@ -198,7 +202,7 @@ class Sandbox(BaseSandbox):
                     "language": language,
                     "env_vars": envs,
                 },
-                headers={"X-Access-Token": self._envd_access_token},
+                headers=headers,
                 timeout=(request_timeout, timeout, request_timeout, request_timeout),
             ) as response:
                 err = extract_exception(response)
@@ -246,11 +250,15 @@ class Sandbox(BaseSandbox):
         if cwd:
             data["cwd"] = cwd
 
+        headers = {}
+        if self._envd_access_token:
+            headers = {"X-Access-Token": self._envd_access_token or ""}
+
         try:
             response = self._client.post(
                 f"{self._jupyter_url}/contexts",
                 json=data,
-                headers={"X-Access-Token": self._envd_access_token},
+                headers=headers,
                 timeout=request_timeout or self.connection_config.request_timeout,
             )
 

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -66,17 +66,6 @@ class ContextWebSocket:
         self._lock = asyncio.Lock()
 
     async def reconnect(self):
-        # The results can be already lost
-        for key, execution in self._executions.items():
-            await execution.queue.put(
-                Error(
-                    name="WebSocketError",
-                    value="The connections was lost, rerun the code to get the results",
-                    traceback="",
-                )
-            )
-            await execution.queue.put(UnexpectedEndOfExecution())
-
         if self._ws is not None:
             await self._ws.close(reason="Reconnecting")
 

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -345,7 +345,7 @@ class ContextWebSocket:
                     break
                 except (ConnectionClosedError, WebSocketException) as e:
                     # Keep the last result, even if error
-                    if i < MAX_RECONNECT_RETRIES - 1:
+                    if i < MAX_RECONNECT_RETRIES:
                         logger.warning(
                             f"WebSocket connection lost while sending execution request, {i + 1}. reconnecting...: {str(e)}"
                         )

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -71,7 +71,7 @@ class ContextWebSocket:
             await execution.queue.put(
                 Error(
                     name="WebSocketError",
-                    value="Failed to send execution request due to unknown error",
+                    value="The connections was lost, rerun the code to get the results",
                     traceback="",
                 )
             )

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -80,6 +80,9 @@ class ContextWebSocket:
         if self._ws is not None:
             await self._ws.close(reason="Reconnecting")
 
+        if self._receive_task is not None:
+            await self._receive_task
+
         await self.connect()
 
     async def connect(self):
@@ -90,7 +93,8 @@ class ContextWebSocket:
 
         self._ws = await connect(
             self.url,
-            ping_timeout=30,
+            ping_timeout=0.03,
+            ping_interval=0.03,
             max_size=None,
             max_queue=None,
             logger=ws_logger,

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -32,7 +32,7 @@ from envs import get_envs
 logger = logging.getLogger(__name__)
 
 MAX_RECONNECT_RETRIES = 3
-PING_TIMEOUT = None
+PING_TIMEOUT = 30
 
 
 class Execution:

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -334,7 +334,7 @@ class ContextWebSocket:
                 )
                 await execution.queue.put(UnexpectedEndOfExecution())
                 return
-            except:
+            except:  # noqa: E722
                 logger.error("Failed to send execution request due to unknown error")
                 await execution.queue.put(
                     Error(

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -361,11 +361,11 @@ class ContextWebSocket:
                         execution = Execution()
                         self._executions[message_id] = execution
             else:
-                logger.error("Failed to send execution request due to unknown error")
+                logger.error("Failed to send execution request")
                 await execution.queue.put(
                     Error(
                         name="WebSocketError",
-                        value="Failed to send execution request due to unknown error",
+                        value="Failed to send execution request",
                         traceback="",
                     )
                 )

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -93,8 +93,7 @@ class ContextWebSocket:
 
         self._ws = await connect(
             self.url,
-            ping_timeout=0.03,
-            ping_interval=0.03,
+            ping_timeout=30,
             max_size=None,
             max_queue=None,
             logger=ws_logger,

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -32,7 +32,7 @@ from envs import get_envs
 logger = logging.getLogger(__name__)
 
 MAX_RECONNECT_RETRIES = 3
-PING_TIMEOUT = 30
+PING_TIMEOUT = None
 
 
 class Execution:

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -329,7 +329,7 @@ class ContextWebSocket:
                     Error(
                         name="WebSocketError",
                         value="Failed to send execution request due to connection error",
-                        traceback=str(e),
+                        traceback="",
                     )
                 )
                 await execution.queue.put(UnexpectedEndOfExecution())

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -333,7 +333,6 @@ class ContextWebSocket:
                     )
                 )
                 await execution.queue.put(UnexpectedEndOfExecution())
-                return
             except:  # noqa: E722
                 logger.error("Failed to send execution request due to unknown error")
                 await execution.queue.put(
@@ -344,7 +343,6 @@ class ContextWebSocket:
                     )
                 )
                 await execution.queue.put(UnexpectedEndOfExecution())
-                return
 
             # Stream the results
             async for item in self._wait_for_result(message_id):

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -348,7 +348,7 @@ class ContextWebSocket:
                     break
                 except (ConnectionClosedError, WebSocketException) as e:
                     logger.warning(
-                        f"WebSocket connection lost while sending execution request, {i+1}. reconnecting...: {str(e)}"
+                        f"WebSocket connection lost while sending execution request, {i + 1}. reconnecting...: {str(e)}"
                     )
                     await self.reconnect()
             else:

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -31,7 +31,7 @@ from envs import get_envs
 
 logger = logging.getLogger(__name__)
 
-MAX_RECONNECT_RETRIES = 1
+MAX_RECONNECT_RETRIES = 3
 PING_TIMEOUT = 30
 
 

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -349,13 +349,13 @@ class ContextWebSocket:
                     await self._ws.send(request)
                     break
                 except (ConnectionClosedError, WebSocketException) as e:
-                    logger.warning(
-                        f"WebSocket connection lost while sending execution request, {i + 1}. reconnecting...: {str(e)}"
-                    )
-                    await self.reconnect()
-
                     # Keep the last result, even if error
                     if i < max_retries - 1:
+                        logger.warning(
+                            f"WebSocket connection lost while sending execution request, {i + 1}. reconnecting...: {str(e)}"
+                        )
+                        await self.reconnect()
+
                         del self._executions[message_id]
                         message_id = str(uuid.uuid4())
                         execution = Execution()


### PR DESCRIPTION
Handle connection error between the server and kernel gracefully
Add reconnect logic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds WebSocket reconnect with retries and ping timeout, conditionally sets auth header in Python clients, and surfaces connection-loss errors to prevent hangs.
> 
> - **Server runtime (`template/server/messaging.py`)**:
>   - **WebSocket resilience**: Add `reconnect()` with `MAX_RECONNECT_RETRIES` and `PING_TIMEOUT`; wrap send in retry loop catching `ConnectionClosedError`/`WebSocketException` and reconnecting.
>   - **Error propagation**: On receiver teardown, enqueue `Error` and `UnexpectedEndOfExecution` for ongoing executions to avoid hangs.
>   - **Execution flow**: Create per-execution `message_id` and `Execution` right before send; serialize request with `_get_execute_request`.
> - **Python client (`python/e2b_code_interpreter/*`)**:
>   - **Auth header handling**: Set `headers` with `X-Access-Token` only if token present for both async and sync `run_code` and `create_code_context`.
> - **Changesets**: Patch releases for `@e2b/code-interpreter-template` (add retry) and `@e2b/code-interpreter-python` (fix header issue).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e51313b12764fedbd9379fb8f7d203070a6502d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->