### PR TITLE
Update base e2b

### DIFF
--- a/.changeset/strong-queens-refuse.md
+++ b/.changeset/strong-queens-refuse.md
@@ -1,0 +1,5 @@
+---
+'@e2b/code-interpreter-python': patch
+---
+
+Update e2b package containing bug fix for autopause

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -415,6 +415,18 @@ wrapt = ">=1.10,<2"
 dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "jinja2 (>=3.0.3,<3.1.0)", "setuptools ; python_version >= \"3.12\"", "sphinx (<2)", "tox"]
 
 [[package]]
+name = "dockerfile-parse"
+version = "2.0.1"
+description = "Python library for Dockerfile manipulation"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "dockerfile-parse-2.0.1.tar.gz", hash = "sha256:3184ccdc513221983e503ac00e1aa504a2aa8f84e5de673c46b0b6eee99ec7bc"},
+    {file = "dockerfile_parse-2.0.1-py2.py3-none-any.whl", hash = "sha256:bdffd126d2eb26acf1066acb54cb2e336682e1d72b974a40894fac76a4df17f6"},
+]
+
+[[package]]
 name = "docspec"
 version = "2.2.1"
 description = "Docspec is a JSON object specification for representing API documentation of programming languages."
@@ -464,18 +476,19 @@ test = ["black", "pytest"]
 
 [[package]]
 name = "e2b"
-version = "2.0.0"
+version = "2.2.1"
 description = "E2B SDK that give agents cloud environments"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
 files = [
-    {file = "e2b-2.0.0-py3-none-any.whl", hash = "sha256:a6621b905cb2a883a9c520736ae98343a6184fc90c29b4f2f079d720294a0df0"},
-    {file = "e2b-2.0.0.tar.gz", hash = "sha256:4d033d937b0a09b8428e73233321a913cbaef8e7299fc731579c656e9d53a144"},
+    {file = "e2b-2.2.1-py3-none-any.whl", hash = "sha256:e5f164dbfe23a6fa77b3932427e37492101faaee57003b2134f43427180edad9"},
+    {file = "e2b-2.2.1.tar.gz", hash = "sha256:306346db5ae19367aa05d5ccb8944c03aebec6cd3fae177aae2475477b2d4658"},
 ]
 
 [package.dependencies]
 attrs = ">=23.2.0"
+dockerfile-parse = ">=2.0.1,<3.0.0"
 httpcore = ">=1.0.5,<2.0.0"
 httpx = ">=0.27.0,<1.0.0"
 packaging = ">=24.1"
@@ -1833,4 +1846,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "c327b7c1391aa1fe74d57cca0f797ee783fe7bf5826b62a2cd6e023bb53d2369"
+content-hash = "145f0167963c614b8bc6970965e84b511e3a361517f4b671a1eea46ef809f41f"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -14,7 +14,7 @@ python = "^3.9"
 
 httpx = ">=0.20.0, <1.0.0"
 attrs = ">=21.3.0"
-e2b = "^2.0.0"
+e2b = "^2.0.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps `e2b` to `^2.0.1`, updates `poetry.lock` (resolves to `e2b 2.2.1` and adds `dockerfile-parse`), and adds a changeset.
> 
> - **Dependencies**:
>   - Bump `e2b` in `python/pyproject.toml` from `^2.0.0` to `^2.0.1`.
>   - Update `python/poetry.lock`:
>     - `e2b` resolved to `2.2.1` with new hashes.
>     - Add transitive dependency `dockerfile-parse@2.0.1`.
>     - Update lockfile metadata `content-hash`.
> - **Repo metadata**:
>   - Add changeset `.changeset/strong-queens-refuse.md` for a patch release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a461cb2f8974356b3157e67a0d289fec8185f38b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->