### PR TITLE
Use OIDC for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,9 @@ jobs:
           version: 9.5
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
@@ -70,9 +70,9 @@ jobs:
           version: 9.5
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
@@ -285,16 +285,22 @@ jobs:
         with:
           version: 9.5
 
-      - name: Setup Node.js 20
-        uses: actions/setup-node@v3
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v6
         with:
-          node-version: "20.x"
+          node-version: "22.x"
+          registry-url: 'https://registry.npmjs.org'
           cache: pnpm
 
       - name: Configure pnpm
         run: |
           pnpm config set auto-install-peers true
           pnpm config set exclude-links-from-lockfile true
+
+      - name: Update npm
+        run: |
+          npm install -g npm@^11.6
+          npm --version
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -323,6 +329,7 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: "" # See https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
       - name: Update lock file


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the release workflow to Node.js 22 and switches npm publishing to OIDC by granting id-token and removing the NPM_TOKEN secret.
> 
> - **CI/CD: Release workflow (`.github/workflows/release.yml`)**
>   - **Node.js / Actions**:
>     - Upgrade `actions/setup-node` to `v6` and Node version to `22.x` across jobs.
>     - Set `registry-url` where missing; keep pnpm caching.
>   - **Authentication**:
>     - Grant `permissions: id-token: write`.
>     - Set `NPM_TOKEN` to an empty string to enable OIDC-based npm publish via Changesets.
>   - **Tooling**:
>     - Add step to update npm to `^11.6` during release job.
>   - **Misc**:
>     - Minor step renames/ordering; no functional changes to job matrix or release logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 124ce8ed23f9ac63d909ff222ee9f4a175c0f64e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->