### PR TITLE
Update e2b core package

### DIFF
--- a/.changeset/brave-olives-play.md
+++ b/.changeset/brave-olives-play.md
@@ -1,0 +1,6 @@
+---
+'@e2b/code-interpreter-python': minor
+'@e2b/code-interpreter': minor
+---
+
+Update e2b version to use the new connect method

--- a/js/package.json
+++ b/js/package.json
@@ -74,6 +74,6 @@
     "defaults"
   ],
   "dependencies": {
-    "e2b": "^2.3.0"
+    "e2b": "^2.6.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
   js:
     dependencies:
       e2b:
-        specifier: ^2.3.0
-        version: 2.3.0
+        specifier: ^2.6.0
+        version: 2.6.0
     devDependencies:
       '@types/node':
         specifier: ^20.19.19
@@ -929,8 +929,8 @@ packages:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
     engines: {node: '>=12'}
 
-  e2b@2.3.0:
-    resolution: {integrity: sha512-EX05vM7XnOuQMBc2IYXg7s5CS0k7cZ6SS++UVjEHSu+AnrBFCqvcaVLfGtjB1xgm7RFdjLvrUuh7sTAoHBTMEg==}
+  e2b@2.6.0:
+    resolution: {integrity: sha512-7hzfZGVZNwh2YU+aviOVRZ0HjFBnKFFQKTNq9CtXuJ0tHlDqeu5G5ZcryejGejnYrgAloxarThK9vE4srqXamQ==}
     engines: {node: '>=20'}
 
   eastasianwidth@0.2.0:
@@ -2896,7 +2896,7 @@ snapshots:
 
   dotenv@16.4.7: {}
 
-  e2b@2.3.0:
+  e2b@2.6.0:
     dependencies:
       '@bufbuild/protobuf': 2.9.0
       '@connectrpc/connect': 2.0.0-rc.3(@bufbuild/protobuf@2.9.0)

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -476,14 +476,14 @@ test = ["black", "pytest"]
 
 [[package]]
 name = "e2b"
-version = "2.3.0"
+version = "2.6.0"
 description = "E2B SDK that give agents cloud environments"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
 files = [
-    {file = "e2b-2.3.0-py3-none-any.whl", hash = "sha256:b686051b50ca2602e227b4dc3861b0eae993c0ed1e2868bf716ef3e9930d0c14"},
-    {file = "e2b-2.3.0.tar.gz", hash = "sha256:f9cd504142188356f62a3309d2516e298a5ec88d73be897ea7c5ef37baf05e23"},
+    {file = "e2b-2.6.0-py3-none-any.whl", hash = "sha256:74fbf9adf5d651862780d281e5f50cfb0286adbeaba6dceac86f26e5e1c0ad8c"},
+    {file = "e2b-2.6.0.tar.gz", hash = "sha256:3c6a8e315748d39efc2b0ff69aa47af548fd9da64be64f6797e5998db324e791"},
 ]
 
 [package.dependencies]
@@ -1916,4 +1916,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "c4e5cc5e77cfdb70cab1f5b59a73ab1bba8bdac2492fb7a583f195cae5f3d104"
+content-hash = "f0f0e653869c2ee8fac2dd97f0a87f9a89c150264da41ea3d2845e6c54ad08b5"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -14,7 +14,7 @@ python = "^3.9"
 
 httpx = ">=0.20.0, <1.0.0"
 attrs = ">=21.3.0"
-e2b = "^2.3.0"
+e2b = "^2.6.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrades the `e2b` SDK to 2.6.0 for JS and Python, updates lockfiles, and adds a changeset for minor package releases to adopt the new connect method.
> 
> - **Dependencies**:
>   - Bump `e2b` from `^2.3.0` to `^2.6.0` in `js/package.json` and `python/pyproject.toml`.
> - **Lockfiles**:
>   - Update `pnpm-lock.yaml` and `python/poetry.lock` to resolve `e2b@2.6.0` and related artifacts.
> - **Release**:
>   - Add changeset `.changeset/brave-olives-play.md` marking minor releases for `@e2b/code-interpreter` and `@e2b/code-interpreter-python` to use the new connect method.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cd0aa7d52467742e07db6143255634aea91736e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->