### PR TITLE
CI: Use E2B Prod API Key for publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -241,7 +241,7 @@ jobs:
         run: |
           python build_prod.py
         env:
-          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          E2B_API_KEY: ${{ secrets.E2B_PROD_API_KEY }}
           E2B_DOMAIN: ${{ vars.E2B_DOMAIN }}
 
   python-tests:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch the E2B API key to `secrets.E2B_PROD_API_KEY` in the `build-template` step of `.github/workflows/release.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 252e15e362124e228f70333abeeb0b3228df7103. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->