### PR TITLE
fix: add `traffic_access_token` to request headers

### DIFF
--- a/js/src/sandbox.ts
+++ b/js/src/sandbox.ts
@@ -226,6 +226,9 @@ export class Sandbox extends BaseSandbox {
     if (this.envdAccessToken) {
       headers['X-Access-Token'] = this.envdAccessToken
     }
+    if (this.trafficAccessToken) {
+      headers['e2b-traffic-access-token'] = this.trafficAccessToken
+    }
 
     try {
       const res = await fetch(`${this.jupyterUrl}/execute`, {
@@ -295,13 +298,21 @@ export class Sandbox extends BaseSandbox {
    * @returns context object.
    */
   async createCodeContext(opts?: CreateCodeContextOpts): Promise<Context> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...this.connectionConfig.headers,
+    }
+    if (this.envdAccessToken) {
+      headers['X-Access-Token'] = this.envdAccessToken
+    }
+    if (this.trafficAccessToken) {
+      headers['e2b-traffic-access-token'] = this.trafficAccessToken
+    }
+
     try {
       const res = await fetch(`${this.jupyterUrl}/contexts`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...this.connectionConfig.headers,
-        },
+        headers,
         body: JSON.stringify({
           language: opts?.language,
           cwd: opts?.cwd,

--- a/python/e2b_code_interpreter/code_interpreter_async.py
+++ b/python/e2b_code_interpreter/code_interpreter_async.py
@@ -193,7 +193,9 @@ class AsyncSandbox(BaseAsyncSandbox):
 
         headers: Dict[str, str] = {}
         if self._envd_access_token:
-            headers = {"X-Access-Token": self._envd_access_token}
+            headers["X-Access-Token"] = self._envd_access_token
+        if self.traffic_access_token:
+            headers["e2b-traffic-access-token"] = self.traffic_access_token
 
         try:
             async with self._client.stream(
@@ -255,7 +257,9 @@ class AsyncSandbox(BaseAsyncSandbox):
 
         headers: Dict[str, str] = {}
         if self._envd_access_token:
-            headers = {"X-Access-Token": self._envd_access_token}
+            headers["X-Access-Token"] = self._envd_access_token
+        if self.traffic_access_token:
+            headers["e2b-traffic-access-token"] = self.traffic_access_token
 
         try:
             response = await self._client.post(

--- a/python/e2b_code_interpreter/code_interpreter_sync.py
+++ b/python/e2b_code_interpreter/code_interpreter_sync.py
@@ -190,7 +190,9 @@ class Sandbox(BaseSandbox):
 
         headers: Dict[str, str] = {}
         if self._envd_access_token:
-            headers = {"X-Access-Token": self._envd_access_token}
+            headers["X-Access-Token"] = self._envd_access_token
+        if self.traffic_access_token:
+            headers["e2b-traffic-access-token"] = self.traffic_access_token
 
         try:
             with self._client.stream(
@@ -252,7 +254,9 @@ class Sandbox(BaseSandbox):
 
         headers: Dict[str, str] = {}
         if self._envd_access_token:
-            headers = {"X-Access-Token": self._envd_access_token}
+            headers["X-Access-Token"] = self._envd_access_token
+        if self.traffic_access_token:
+            headers["e2b-traffic-access-token"] = self.traffic_access_token
 
         try:
             response = self._client.post(


### PR DESCRIPTION
closes #177 

it seems .envdAccessToken was not passed to the createContext method in the JS SDK unlike the Python one, so I added that too. but tbh I have no idea what its for.