### PR TITLE
fix(python): route Jupyter requests through client-proxy when E2B_SANDBOX_URL is set

### DIFF
--- a/python/e2b_code_interpreter/code_interpreter_async.py
+++ b/python/e2b_code_interpreter/code_interpreter_async.py
@@ -58,7 +58,22 @@ class AsyncSandbox(BaseAsyncSandbox):
 
     @property
     def _jupyter_url(self) -> str:
+        # When E2B_SANDBOX_URL is set (local/self-hosted environment), route through the client-proxy
+        sandbox_url = self.connection_config._sandbox_url
+        if sandbox_url:
+            return sandbox_url
         return f"{'http' if self.connection_config.debug else 'https'}://{self.get_host(JUPYTER_PORT)}"
+
+    @property
+    def _jupyter_headers(self) -> Dict[str, str]:
+        """Extra headers for local client-proxy routing (E2b-Sandbox-Id / E2b-Sandbox-Port)."""
+        sandbox_url = self.connection_config._sandbox_url
+        if sandbox_url:
+            return {
+                "E2b-Sandbox-Id": self.sandbox_id,
+                "E2b-Sandbox-Port": str(JUPYTER_PORT),
+            }
+        return {}
 
     @property
     def _client(self) -> AsyncClient:
@@ -194,6 +209,7 @@ class AsyncSandbox(BaseAsyncSandbox):
             headers = {
                 "Content-Type": "application/json",
             }
+            headers.update(self._jupyter_headers)
             if self._envd_access_token:
                 headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
@@ -260,6 +276,7 @@ class AsyncSandbox(BaseAsyncSandbox):
             headers = {
                 "Content-Type": "application/json",
             }
+            headers.update(self._jupyter_headers)
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token
 
@@ -296,6 +313,7 @@ class AsyncSandbox(BaseAsyncSandbox):
             headers = {
                 "Content-Type": "application/json",
             }
+            headers.update(self._jupyter_headers)
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token
 
@@ -321,6 +339,7 @@ class AsyncSandbox(BaseAsyncSandbox):
             headers = {
                 "Content-Type": "application/json",
             }
+            headers.update(self._jupyter_headers)
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token
 
@@ -355,6 +374,7 @@ class AsyncSandbox(BaseAsyncSandbox):
             headers = {
                 "Content-Type": "application/json",
             }
+            headers.update(self._jupyter_headers)
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token
 

--- a/python/e2b_code_interpreter/code_interpreter_sync.py
+++ b/python/e2b_code_interpreter/code_interpreter_sync.py
@@ -55,7 +55,22 @@ class Sandbox(BaseSandbox):
 
     @property
     def _jupyter_url(self) -> str:
+        # When E2B_SANDBOX_URL is set (local environment), route through the client-proxy
+        sandbox_url = self.connection_config._sandbox_url
+        if sandbox_url:
+            return sandbox_url
         return f"{'http' if self.connection_config.debug else 'https'}://{self.get_host(JUPYTER_PORT)}"
+
+    @property
+    def _jupyter_headers(self) -> Dict[str, str]:
+        """Extra headers for local client-proxy routing (E2b-Sandbox-Id / E2b-Sandbox-Port)."""
+        sandbox_url = self.connection_config._sandbox_url
+        if sandbox_url:
+            return {
+                "E2b-Sandbox-Id": self.sandbox_id,
+                "E2b-Sandbox-Port": str(JUPYTER_PORT),
+            }
+        return {}
 
     @property
     def _client(self) -> Client:
@@ -190,6 +205,7 @@ class Sandbox(BaseSandbox):
 
         try:
             headers: Dict[str, str] = {"Content-Type": "application/json"}
+            headers.update(self._jupyter_headers)
             if self._envd_access_token:
                 headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
@@ -254,6 +270,7 @@ class Sandbox(BaseSandbox):
 
         try:
             headers: Dict[str, str] = {"Content-Type": "application/json"}
+            headers.update(self._jupyter_headers)
             if self._envd_access_token:
                 headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
@@ -290,6 +307,7 @@ class Sandbox(BaseSandbox):
 
         try:
             headers: Dict[str, str] = {"Content-Type": "application/json"}
+            headers.update(self._jupyter_headers)
             if self._envd_access_token:
                 headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
@@ -315,6 +333,7 @@ class Sandbox(BaseSandbox):
         """
         try:
             headers: Dict[str, str] = {"Content-Type": "application/json"}
+            headers.update(self._jupyter_headers)
             if self._envd_access_token:
                 headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
@@ -350,6 +369,7 @@ class Sandbox(BaseSandbox):
 
         try:
             headers: Dict[str, str] = {"Content-Type": "application/json"}
+            headers.update(self._jupyter_headers)
             if self._envd_access_token:
                 headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:


### PR DESCRIPTION
## Summary

- When `E2B_SANDBOX_URL` is set (local/self-hosted environments), the code interpreter SDK's Jupyter requests (`run_code`, `create_code_context`, etc.) bypass `E2B_SANDBOX_URL` and are sent directly to the hostname-based URL (e.g. `https://49999-{sandbox_id}.e2b.app`), which fails in local setups.
- The base SDK (`e2b`) correctly handles this via `get_sandbox_url()`, but the code interpreter's `_jupyter_url` uses `get_host()` directly.
- This fix updates `_jupyter_url` to respect `E2B_SANDBOX_URL` and adds `E2b-Sandbox-Id` / `E2b-Sandbox-Port` headers for local client-proxy routing.
- Both sync (`Sandbox`) and async (`AsyncSandbox`) classes are fixed.
- Cloud users are unaffected (`E2B_SANDBOX_URL` is not set in cloud flow).

## Test plan

- [x] Tested with local E2B infrastructure (API at localhost:3000, client-proxy at localhost:3002)
- [x] Verified `run_code()` works with stateful execution (variable persistence across calls)
- [ ] Cloud environment regression test (no behavioral change expected when `E2B_SANDBOX_URL` is not set)