### PR TITLE
Add language autocomplete for supported languages

### DIFF
--- a/.changeset/add-language-overloads.md
+++ b/.changeset/add-language-overloads.md
@@ -1,0 +1,6 @@
+---
+"@e2b/code-interpreter": patch
+"e2b-code-interpreter": patch
+---
+
+Add autocomplete support for javascript, typescript, r, java, and bash languages in runCode/run_code and createCodeContext/create_code_context

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -1,7 +1,12 @@
 export * from 'e2b'
 
 export { Sandbox } from './sandbox'
-export type { Context, RunCodeLanguage, RunCodeOpts, CreateCodeContextOpts } from './sandbox'
+export type {
+  Context,
+  RunCodeLanguage,
+  RunCodeOpts,
+  CreateCodeContextOpts,
+} from './sandbox'
 export type {
   Logs,
   ExecutionError,

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -1,7 +1,7 @@
 export * from 'e2b'
 
 export { Sandbox } from './sandbox'
-export type { Context, RunCodeOpts, CreateCodeContextOpts } from './sandbox'
+export type { Context, RunCodeLanguage, RunCodeOpts, CreateCodeContextOpts } from './sandbox'
 export type {
   Logs,
   ExecutionError,

--- a/js/src/sandbox.ts
+++ b/js/src/sandbox.ts
@@ -33,6 +33,20 @@ export type Context = {
   cwd: string
 }
 
+/* eslint-disable @typescript-eslint/ban-types */
+/**
+ * Supported language for code execution.
+ */
+export type RunCodeLanguage =
+  | 'python'
+  | 'javascript'
+  | 'typescript'
+  | 'r'
+  | 'java'
+  | 'bash'
+  | (string & {})
+/* eslint-enable @typescript-eslint/ban-types */
+
 /**
  * Options for running code.
  */
@@ -88,16 +102,7 @@ export interface CreateCodeContextOpts {
    *
    * @default python
    */
-  /* eslint-disable @typescript-eslint/ban-types */
-  language?:
-    | 'python'
-    | 'javascript'
-    | 'typescript'
-    | 'r'
-    | 'java'
-    | 'bash'
-    | (string & {})
-  /* eslint-enable @typescript-eslint/ban-types */
+  language?: RunCodeLanguage
   /**
    * Timeout for the request in **milliseconds**.
    *
@@ -158,16 +163,7 @@ export class Sandbox extends BaseSandbox {
        *
        * If not defined, the default Python context is used.
        */
-      /* eslint-disable @typescript-eslint/ban-types */
-      language?:
-        | 'python'
-        | 'javascript'
-        | 'typescript'
-        | 'r'
-        | 'java'
-        | 'bash'
-        | (string & {})
-      /* eslint-enable @typescript-eslint/ban-types */
+      language?: RunCodeLanguage
     }
   ): Promise<Execution>
   /**

--- a/js/src/sandbox.ts
+++ b/js/src/sandbox.ts
@@ -88,7 +88,7 @@ export interface CreateCodeContextOpts {
    *
    * @default python
    */
-  // eslint-disable-next-line @typescript-eslint/ban-types
+  /* eslint-disable @typescript-eslint/ban-types */
   language?:
     | 'python'
     | 'javascript'
@@ -97,6 +97,7 @@ export interface CreateCodeContextOpts {
     | 'java'
     | 'bash'
     | (string & {})
+  /* eslint-enable @typescript-eslint/ban-types */
   /**
    * Timeout for the request in **milliseconds**.
    *
@@ -157,7 +158,7 @@ export class Sandbox extends BaseSandbox {
        *
        * If not defined, the default Python context is used.
        */
-      // eslint-disable-next-line @typescript-eslint/ban-types
+      /* eslint-disable @typescript-eslint/ban-types */
       language?:
         | 'python'
         | 'javascript'
@@ -166,6 +167,7 @@ export class Sandbox extends BaseSandbox {
         | 'java'
         | 'bash'
         | (string & {})
+      /* eslint-enable @typescript-eslint/ban-types */
     }
   ): Promise<Execution>
   /**

--- a/js/src/sandbox.ts
+++ b/js/src/sandbox.ts
@@ -88,7 +88,7 @@ export interface CreateCodeContextOpts {
    *
    * @default python
    */
-  language?: string
+  language?: 'python' | 'javascript' | 'typescript' | 'r' | 'java' | 'bash' | (string & {})
   /**
    * Timeout for the request in **milliseconds**.
    *
@@ -129,29 +129,6 @@ export class Sandbox extends BaseSandbox {
   }
 
   /**
-   * Run the code as Python.
-   *
-   * Specify the `language` or `context` option to run the code as a different language or in a different `Context`.
-   *
-   * You can reference previously defined variables, imports, and functions in the code.
-   *
-   * @param code code to execute.
-   * @param opts options for executing the code.
-   *
-   * @returns `Execution` result object.
-   */
-  async runCode(
-    code: string,
-    opts?: RunCodeOpts & {
-      /**
-       * Language to use for code execution.
-       *
-       * If not defined, the default Python context is used.
-       */
-      language?: 'python'
-    }
-  ): Promise<Execution>
-  /**
    * Run the code for the specified language.
    *
    * Specify the `language` or `context` option to run the code as a different language or in a different `Context`.
@@ -172,7 +149,7 @@ export class Sandbox extends BaseSandbox {
        *
        * If not defined, the default Python context is used.
        */
-      language?: string
+      language?: 'python' | 'javascript' | 'typescript' | 'r' | 'java' | 'bash' | (string & {})
     }
   ): Promise<Execution>
   /**

--- a/js/src/sandbox.ts
+++ b/js/src/sandbox.ts
@@ -88,7 +88,7 @@ export interface CreateCodeContextOpts {
    *
    * @default python
    */
-  language?: 'python' | 'javascript' | 'typescript' | 'r' | 'java' | 'bash' | (string & {})
+  language?: 'python' | 'javascript' | 'typescript' | 'r' | 'java' | 'bash' | (string & NonNullable<unknown>)
   /**
    * Timeout for the request in **milliseconds**.
    *
@@ -149,7 +149,7 @@ export class Sandbox extends BaseSandbox {
        *
        * If not defined, the default Python context is used.
        */
-      language?: 'python' | 'javascript' | 'typescript' | 'r' | 'java' | 'bash' | (string & {})
+      language?: 'python' | 'javascript' | 'typescript' | 'r' | 'java' | 'bash' | (string & NonNullable<unknown>)
     }
   ): Promise<Execution>
   /**

--- a/js/src/sandbox.ts
+++ b/js/src/sandbox.ts
@@ -88,7 +88,7 @@ export interface CreateCodeContextOpts {
    *
    * @default python
    */
-  language?: 'python' | 'javascript' | 'typescript' | 'r' | 'java' | 'bash' | (string & NonNullable<unknown>)
+  language?: 'python' | 'javascript' | 'typescript' | 'r' | 'java' | 'bash' | string
   /**
    * Timeout for the request in **milliseconds**.
    *
@@ -149,7 +149,7 @@ export class Sandbox extends BaseSandbox {
        *
        * If not defined, the default Python context is used.
        */
-      language?: 'python' | 'javascript' | 'typescript' | 'r' | 'java' | 'bash' | (string & NonNullable<unknown>)
+      language?: 'python' | 'javascript' | 'typescript' | 'r' | 'java' | 'bash' | string
     }
   ): Promise<Execution>
   /**

--- a/js/src/sandbox.ts
+++ b/js/src/sandbox.ts
@@ -88,7 +88,8 @@ export interface CreateCodeContextOpts {
    *
    * @default python
    */
-  language?: 'python' | 'javascript' | 'typescript' | 'r' | 'java' | 'bash' | string
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  language?: 'python' | 'javascript' | 'typescript' | 'r' | 'java' | 'bash' | (string & {})
   /**
    * Timeout for the request in **milliseconds**.
    *
@@ -149,7 +150,8 @@ export class Sandbox extends BaseSandbox {
        *
        * If not defined, the default Python context is used.
        */
-      language?: 'python' | 'javascript' | 'typescript' | 'r' | 'java' | 'bash' | string
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      language?: 'python' | 'javascript' | 'typescript' | 'r' | 'java' | 'bash' | (string & {})
     }
   ): Promise<Execution>
   /**

--- a/js/src/sandbox.ts
+++ b/js/src/sandbox.ts
@@ -89,7 +89,14 @@ export interface CreateCodeContextOpts {
    * @default python
    */
   // eslint-disable-next-line @typescript-eslint/ban-types
-  language?: 'python' | 'javascript' | 'typescript' | 'r' | 'java' | 'bash' | (string & {})
+  language?:
+    | 'python'
+    | 'javascript'
+    | 'typescript'
+    | 'r'
+    | 'java'
+    | 'bash'
+    | (string & {})
   /**
    * Timeout for the request in **milliseconds**.
    *
@@ -151,7 +158,14 @@ export class Sandbox extends BaseSandbox {
        * If not defined, the default Python context is used.
        */
       // eslint-disable-next-line @typescript-eslint/ban-types
-      language?: 'python' | 'javascript' | 'typescript' | 'r' | 'java' | 'bash' | (string & {})
+      language?:
+        | 'python'
+        | 'javascript'
+        | 'typescript'
+        | 'r'
+        | 'java'
+        | 'bash'
+        | (string & {})
     }
   ): Promise<Execution>
   /**

--- a/python/e2b_code_interpreter/__init__.py
+++ b/python/e2b_code_interpreter/__init__.py
@@ -10,4 +10,5 @@ from .models import (
     Logs,
     OutputHandler,
     OutputMessage,
+    RunCodeLanguage,
 )

--- a/python/e2b_code_interpreter/code_interpreter_async.py
+++ b/python/e2b_code_interpreter/code_interpreter_async.py
@@ -68,41 +68,7 @@ class AsyncSandbox(BaseAsyncSandbox):
     async def run_code(
         self,
         code: str,
-        language: Union[Literal["python"], None] = None,
-        on_stdout: Optional[OutputHandlerWithAsync[OutputMessage]] = None,
-        on_stderr: Optional[OutputHandlerWithAsync[OutputMessage]] = None,
-        on_result: Optional[OutputHandlerWithAsync[Result]] = None,
-        on_error: Optional[OutputHandlerWithAsync[ExecutionError]] = None,
-        envs: Optional[Dict[str, str]] = None,
-        timeout: Optional[float] = None,
-        request_timeout: Optional[float] = None,
-    ) -> Execution:
-        """
-        Runs the code as Python.
-
-        Specify the `language` or `context` option to run the code as a different language or in a different `Context`.
-
-        You can reference previously defined variables, imports, and functions in the code.
-
-        :param code: Code to execute
-        :param language: Language to use for code execution. If not defined, the default Python context is used.
-        :param on_stdout: Callback for stdout messages
-        :param on_stderr: Callback for stderr messages
-        :param on_result: Callback for the `Result` object
-        :param on_error: Callback for the `ExecutionError` object
-        :param envs: Custom environment variables
-        :param timeout: Timeout for the code execution in **seconds**
-        :param request_timeout: Timeout for the request in **seconds**
-
-        :return: `Execution` result object
-        """
-        ...
-
-    @overload
-    async def run_code(
-        self,
-        code: str,
-        language: Optional[str] = None,
+        language: Union[Literal["python", "javascript", "typescript", "r", "java", "bash"], str, None] = None,
         on_stdout: Optional[OutputHandlerWithAsync[OutputMessage]] = None,
         on_stderr: Optional[OutputHandlerWithAsync[OutputMessage]] = None,
         on_result: Optional[OutputHandlerWithAsync[Result]] = None,
@@ -236,7 +202,7 @@ class AsyncSandbox(BaseAsyncSandbox):
     async def create_code_context(
         self,
         cwd: Optional[str] = None,
-        language: Optional[str] = None,
+        language: Union[Literal["python", "javascript", "typescript", "r", "java", "bash"], str, None] = None,
         request_timeout: Optional[float] = None,
     ) -> Context:
         """

--- a/python/e2b_code_interpreter/code_interpreter_async.py
+++ b/python/e2b_code_interpreter/code_interpreter_async.py
@@ -1,7 +1,7 @@
 import logging
 import httpx
 
-from typing import Optional, Dict, overload, Union, Literal, List
+from typing import Optional, Dict, overload, Union, List
 from httpx import AsyncClient
 
 from e2b import (
@@ -18,6 +18,7 @@ from e2b_code_interpreter.models import (
     Execution,
     ExecutionError,
     Context,
+    RunCodeLanguage,
     Result,
     aextract_exception,
     OutputHandlerWithAsync,
@@ -68,11 +69,7 @@ class AsyncSandbox(BaseAsyncSandbox):
     async def run_code(
         self,
         code: str,
-        language: Union[
-            Literal["python", "javascript", "typescript", "r", "java", "bash"],
-            str,
-            None,
-        ] = None,
+        language: RunCodeLanguage = None,
         on_stdout: Optional[OutputHandlerWithAsync[OutputMessage]] = None,
         on_stderr: Optional[OutputHandlerWithAsync[OutputMessage]] = None,
         on_result: Optional[OutputHandlerWithAsync[Result]] = None,
@@ -206,11 +203,7 @@ class AsyncSandbox(BaseAsyncSandbox):
     async def create_code_context(
         self,
         cwd: Optional[str] = None,
-        language: Union[
-            Literal["python", "javascript", "typescript", "r", "java", "bash"],
-            str,
-            None,
-        ] = None,
+        language: RunCodeLanguage = None,
         request_timeout: Optional[float] = None,
     ) -> Context:
         """

--- a/python/e2b_code_interpreter/code_interpreter_async.py
+++ b/python/e2b_code_interpreter/code_interpreter_async.py
@@ -69,7 +69,7 @@ class AsyncSandbox(BaseAsyncSandbox):
     async def run_code(
         self,
         code: str,
-        language: RunCodeLanguage = None,
+        language: Optional[RunCodeLanguage] = None,
         on_stdout: Optional[OutputHandlerWithAsync[OutputMessage]] = None,
         on_stderr: Optional[OutputHandlerWithAsync[OutputMessage]] = None,
         on_result: Optional[OutputHandlerWithAsync[Result]] = None,
@@ -203,7 +203,7 @@ class AsyncSandbox(BaseAsyncSandbox):
     async def create_code_context(
         self,
         cwd: Optional[str] = None,
-        language: RunCodeLanguage = None,
+        language: Optional[RunCodeLanguage] = None,
         request_timeout: Optional[float] = None,
     ) -> Context:
         """

--- a/python/e2b_code_interpreter/code_interpreter_async.py
+++ b/python/e2b_code_interpreter/code_interpreter_async.py
@@ -68,7 +68,11 @@ class AsyncSandbox(BaseAsyncSandbox):
     async def run_code(
         self,
         code: str,
-        language: Union[Literal["python", "javascript", "typescript", "r", "java", "bash"], str, None] = None,
+        language: Union[
+            Literal["python", "javascript", "typescript", "r", "java", "bash"],
+            str,
+            None,
+        ] = None,
         on_stdout: Optional[OutputHandlerWithAsync[OutputMessage]] = None,
         on_stderr: Optional[OutputHandlerWithAsync[OutputMessage]] = None,
         on_result: Optional[OutputHandlerWithAsync[Result]] = None,
@@ -202,7 +206,11 @@ class AsyncSandbox(BaseAsyncSandbox):
     async def create_code_context(
         self,
         cwd: Optional[str] = None,
-        language: Union[Literal["python", "javascript", "typescript", "r", "java", "bash"], str, None] = None,
+        language: Union[
+            Literal["python", "javascript", "typescript", "r", "java", "bash"],
+            str,
+            None,
+        ] = None,
         request_timeout: Optional[float] = None,
     ) -> Context:
         """

--- a/python/e2b_code_interpreter/code_interpreter_sync.py
+++ b/python/e2b_code_interpreter/code_interpreter_sync.py
@@ -65,41 +65,7 @@ class Sandbox(BaseSandbox):
     def run_code(
         self,
         code: str,
-        language: Union[Literal["python"], None] = None,
-        on_stdout: Optional[OutputHandler[OutputMessage]] = None,
-        on_stderr: Optional[OutputHandler[OutputMessage]] = None,
-        on_result: Optional[OutputHandler[Result]] = None,
-        on_error: Optional[OutputHandler[ExecutionError]] = None,
-        envs: Optional[Dict[str, str]] = None,
-        timeout: Optional[float] = None,
-        request_timeout: Optional[float] = None,
-    ) -> Execution:
-        """
-        Runs the code as Python.
-
-        Specify the `language` or `context` option to run the code as a different language or in a different `Context`.
-
-        You can reference previously defined variables, imports, and functions in the code.
-
-        :param code: Code to execute
-        :param language: Language to use for code execution. If not defined, the default Python context is used.
-        :param on_stdout: Callback for stdout messages
-        :param on_stderr: Callback for stderr messages
-        :param on_result: Callback for the `Result` object
-        :param on_error: Callback for the `ExecutionError` object
-        :param envs: Custom environment variables
-        :param timeout: Timeout for the code execution in **seconds**
-        :param request_timeout: Timeout for the request in **seconds**
-
-        :return: `Execution` result object
-        """
-        ...
-
-    @overload
-    def run_code(
-        self,
-        code: str,
-        language: Optional[str] = None,
+        language: Union[Literal["python", "javascript", "typescript", "r", "java", "bash"], str, None] = None,
         on_stdout: Optional[OutputHandler[OutputMessage]] = None,
         on_stderr: Optional[OutputHandler[OutputMessage]] = None,
         on_result: Optional[OutputHandler[Result]] = None,
@@ -232,7 +198,7 @@ class Sandbox(BaseSandbox):
     def create_code_context(
         self,
         cwd: Optional[str] = None,
-        language: Optional[str] = None,
+        language: Union[Literal["python", "javascript", "typescript", "r", "java", "bash"], str, None] = None,
         request_timeout: Optional[float] = None,
     ) -> Context:
         """

--- a/python/e2b_code_interpreter/code_interpreter_sync.py
+++ b/python/e2b_code_interpreter/code_interpreter_sync.py
@@ -1,7 +1,7 @@
 import logging
 import httpx
 
-from typing import Optional, Dict, overload, Literal, Union, List
+from typing import Optional, Dict, overload, Union, List
 from httpx import Client
 from e2b import Sandbox as BaseSandbox, InvalidArgumentException
 
@@ -13,6 +13,7 @@ from e2b_code_interpreter.constants import (
 from e2b_code_interpreter.models import (
     ExecutionError,
     Execution,
+    RunCodeLanguage,
     Context,
     Result,
     extract_exception,
@@ -65,11 +66,7 @@ class Sandbox(BaseSandbox):
     def run_code(
         self,
         code: str,
-        language: Union[
-            Literal["python", "javascript", "typescript", "r", "java", "bash"],
-            str,
-            None,
-        ] = None,
+        language: RunCodeLanguage = None,
         on_stdout: Optional[OutputHandler[OutputMessage]] = None,
         on_stderr: Optional[OutputHandler[OutputMessage]] = None,
         on_result: Optional[OutputHandler[Result]] = None,
@@ -202,11 +199,7 @@ class Sandbox(BaseSandbox):
     def create_code_context(
         self,
         cwd: Optional[str] = None,
-        language: Union[
-            Literal["python", "javascript", "typescript", "r", "java", "bash"],
-            str,
-            None,
-        ] = None,
+        language: RunCodeLanguage = None,
         request_timeout: Optional[float] = None,
     ) -> Context:
         """

--- a/python/e2b_code_interpreter/code_interpreter_sync.py
+++ b/python/e2b_code_interpreter/code_interpreter_sync.py
@@ -65,7 +65,11 @@ class Sandbox(BaseSandbox):
     def run_code(
         self,
         code: str,
-        language: Union[Literal["python", "javascript", "typescript", "r", "java", "bash"], str, None] = None,
+        language: Union[
+            Literal["python", "javascript", "typescript", "r", "java", "bash"],
+            str,
+            None,
+        ] = None,
         on_stdout: Optional[OutputHandler[OutputMessage]] = None,
         on_stderr: Optional[OutputHandler[OutputMessage]] = None,
         on_result: Optional[OutputHandler[Result]] = None,
@@ -198,7 +202,11 @@ class Sandbox(BaseSandbox):
     def create_code_context(
         self,
         cwd: Optional[str] = None,
-        language: Union[Literal["python", "javascript", "typescript", "r", "java", "bash"], str, None] = None,
+        language: Union[
+            Literal["python", "javascript", "typescript", "r", "java", "bash"],
+            str,
+            None,
+        ] = None,
         request_timeout: Optional[float] = None,
     ) -> Context:
         """

--- a/python/e2b_code_interpreter/code_interpreter_sync.py
+++ b/python/e2b_code_interpreter/code_interpreter_sync.py
@@ -66,7 +66,7 @@ class Sandbox(BaseSandbox):
     def run_code(
         self,
         code: str,
-        language: RunCodeLanguage = None,
+        language: Optional[RunCodeLanguage] = None,
         on_stdout: Optional[OutputHandler[OutputMessage]] = None,
         on_stderr: Optional[OutputHandler[OutputMessage]] = None,
         on_result: Optional[OutputHandler[Result]] = None,
@@ -199,7 +199,7 @@ class Sandbox(BaseSandbox):
     def create_code_context(
         self,
         cwd: Optional[str] = None,
-        language: RunCodeLanguage = None,
+        language: Optional[RunCodeLanguage] = None,
         request_timeout: Optional[float] = None,
     ) -> Context:
         """

--- a/python/e2b_code_interpreter/models.py
+++ b/python/e2b_code_interpreter/models.py
@@ -24,7 +24,6 @@ from .charts import Chart, _deserialize_chart
 RunCodeLanguage = Union[
     Literal["python", "javascript", "typescript", "r", "java", "bash"],
     str,
-    None,
 ]
 
 T = TypeVar("T")

--- a/python/e2b_code_interpreter/models.py
+++ b/python/e2b_code_interpreter/models.py
@@ -6,6 +6,7 @@ from e2b import NotFoundException, TimeoutException, SandboxException
 from dataclasses import dataclass, field
 from typing import (
     List,
+    Literal,
     Optional,
     Iterable,
     Dict,
@@ -19,6 +20,12 @@ from typing import (
 from httpx import Response
 
 from .charts import Chart, _deserialize_chart
+
+RunCodeLanguage = Union[
+    Literal["python", "javascript", "typescript", "r", "java", "bash"],
+    str,
+    None,
+]
 
 T = TypeVar("T")
 OutputHandler = Union[Callable[[T], Any],]


### PR DESCRIPTION
## Summary
- Add autocomplete/type hints for `javascript`, `typescript`, `r`, `java`, and `bash` languages in `runCode`/`run_code` and `createCodeContext`/`create_code_context`
- Consolidate the Python-specific `Literal["python"]` overload and the generic `str` overload into a single overload with a union of known language literals
- Use `(string & {})` trick in TypeScript to preserve autocomplete while still accepting arbitrary strings

## Test plan
- [x] Verify IDE autocomplete suggests all six languages in TypeScript
- [x] Verify IDE autocomplete suggests all six languages in Python

🤖 Generated with [Claude Code](https://claude.com/claude-code)