### PR TITLE
fix: replace O(n²) string concatenation in readLines with array buffering

### DIFF
--- a/js/src/utils.ts
+++ b/js/src/utils.ts
@@ -30,6 +30,8 @@ export async function* readLines(stream: ReadableStream<Uint8Array>) {
       const { done, value } = await reader.read()
 
       if (done) {
+        const trailing = decoder.decode()
+        if (trailing) pending.push(trailing)
         if (pending.length > 0) {
           yield pending.join('')
         }

--- a/js/src/utils.ts
+++ b/js/src/utils.ts
@@ -22,32 +22,48 @@ export function formatExecutionTimeoutError(error: unknown) {
 
 export async function* readLines(stream: ReadableStream<Uint8Array>) {
   const reader = stream.getReader()
-  let buffer = ''
+  const decoder = new TextDecoder()
+  const pending: string[] = []
 
   try {
     while (true) {
       const { done, value } = await reader.read()
 
-      if (value !== undefined) {
-        buffer += new TextDecoder().decode(value)
-      }
-
       if (done) {
-        if (buffer.length > 0) {
-          yield buffer
+        if (pending.length > 0) {
+          yield pending.join('')
         }
         break
       }
 
-      let newlineIdx = -1
+      if (value !== undefined) {
+        const chunk = decoder.decode(value, { stream: true })
 
-      do {
-        newlineIdx = buffer.indexOf('\n')
-        if (newlineIdx !== -1) {
-          yield buffer.slice(0, newlineIdx)
-          buffer = buffer.slice(newlineIdx + 1)
+        if (chunk.indexOf('\n') === -1) {
+          // No newline — accumulate in O(1)
+          pending.push(chunk)
+          continue
         }
-      } while (newlineIdx !== -1)
+
+        // Chunk contains newline(s) — split and yield complete lines
+        const parts = chunk.split('\n')
+
+        // First part completes the pending line
+        pending.push(parts[0])
+        yield pending.join('')
+        pending.length = 0
+
+        // Middle parts are already complete lines
+        for (let i = 1; i < parts.length - 1; i++) {
+          yield parts[i]
+        }
+
+        // Last part starts a new pending line (may be empty)
+        const last = parts[parts.length - 1]
+        if (last.length > 0) {
+          pending.push(last)
+        }
+      }
     }
   } finally {
     reader.releaseLock()


### PR DESCRIPTION
## Summary

Fixes #251 — replaces quadratic `buffer += chunk` string concatenation in `readLines()` with O(n) array-based buffering.

## Problem

`readLines()` in `js/src/utils.ts` uses `buffer += new TextDecoder().decode(value)` followed by `buffer.indexOf('\n')` on every chunk. The `indexOf` call forces V8 to flatten its internal cons-string representation, defeating the optimization that normally makes `+=` amortized. For 22 MB of stdout arriving in ~1,400 chunks of ~16 KB:

- **Total bytes copied:** ~15.7 GB of string allocations
- **Peak heap:** 1.5 GB+
- **Event loop stalls:** 10-20 seconds

## Fix

Replace with a `pending: string[]` array buffer:

- **No-newline chunks:** O(1) `push()` — no string copying at all
- **Newline chunks:** O(line_length) `join()`, called once per complete line
- **Worst case (no newlines):** single `join()` at stream end

| Metric | Before (`buffer +=`) | After (array + join) |
|--------|---------------------|---------------------|
| Peak heap | 211 MB | **20 MB** |
| Peak RSS | 329 MB | **95 MB** |
| Elapsed time | 29.8s | **4.1s** |
| Memory amplification | 9x | **0.9x** |

*(Benchmark numbers from #251)*

## Test plan

- [x] `npm run build` passes
- [ ] Existing tests pass (requires code-interpreter template — not available in test account, all failures are `template not found`)