### PR TITLE
Fix #200: Dependency Dashboard

### DIFF
--- a/template/requirements.txt
+++ b/template/requirements.txt
@@ -28,7 +28,7 @@ plotly==6.0.1
 kaleido==1.0.0
 pytest==8.3.5
 python-docx==1.1.2
-pytz==2025.2
+pytz==2026.1.post1
 requests==2.33.0
 scikit-image==0.25.2
 scikit-learn==1.6.1
@@ -39,6 +39,6 @@ spacy==3.8.11
 textblob==0.19.0
 tornado==6.5.5
 urllib3==2.6.3
-xarray==2025.4.0
+xarray==2026.1.0
 xlrd==2.0.2
 sympy==1.14.0


### PR DESCRIPTION
Closes #200

Updates `pytz` from `2025.2` to `2026.1.post1` and `xarray` from `2025.4.0` to `2026.1.0` in `template/requirements.txt`.

## Changes

**`template/requirements.txt`**
- Line 31: `pytz==2025.2` → `pytz==2026.1.post1`
- Line 42: `xarray==2025.4.0` → `xarray==2026.1.0`

## Motivation

Both `pytz` and `xarray` released new major versions in 2026. `pytz==2026.1.post1` includes updated timezone data for 2026 DST rules and corrections. `xarray==2026.1.0` is the latest stable release with bug fixes and compatibility improvements. Keeping these current ensures the sandbox template environment reflects accurate timezone handling and up-to-date array/dataset functionality.

## Testing

Verify the updated dependencies install cleanly and the existing test suite passes:

```
pip install -r template/requirements.txt
pytest
```

Confirm no import errors or API breakage from `xarray` 2026.1.0 (the 2025→2026 bump is a calendar-versioned release, not a semantic major break) and that `pytz` timezone lookups behave correctly for post-2025 rules.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*