### PR TITLE
Fix Release workflow by installing npm via tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,8 +344,16 @@ jobs:
           pnpm config set exclude-links-from-lockfile true
 
       - name: Update npm
+        # Workaround: the pre-installed npm on the Node 22 runner image ships
+        # with a broken @npmcli/arborist (missing promise-retry), so `npm
+        # install -g npm@11` fails during reify. Replace npm via tarball.
+        # npm 11+ is required for OIDC trusted publishing (NPM_TOKEN="").
         run: |
-          npm install -g npm@^11.6
+          NPM_VERSION="11.9.0"
+          NPM_DIR="$(dirname "$(dirname "$(which node)")")/lib/node_modules/npm"
+          sudo rm -rf "${NPM_DIR}"
+          sudo mkdir -p "${NPM_DIR}"
+          curl -fsSL "https://registry.npmjs.org/npm/-/npm-${NPM_VERSION}.tgz" | sudo tar -xz -C "${NPM_DIR}" --strip-components=1
           npm --version
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,16 +344,19 @@ jobs:
           pnpm config set exclude-links-from-lockfile true
 
       - name: Update npm
-        # Workaround: the pre-installed npm on the Node 22 runner image ships
-        # with a broken @npmcli/arborist (missing promise-retry), so `npm
-        # install -g npm@11` fails during reify. Replace npm via tarball.
-        # npm 11+ is required for OIDC trusted publishing (NPM_TOKEN="").
+        # The Node 22 runner image ships npm 10.9.7, whose @npmcli/arborist
+        # lazy-loads promise-retry and crashes mid self-upgrade. npm 10.9.8
+        # (arborist 8.0.5) fixed that by eagerly loading it. We tarball-install
+        # 10.9.8 as a bootstrap, then use normal `npm install -g` to reach
+        # npm 11+ which is required for OIDC trusted publishing.
+        # TODO: drop the tarball step once the runner image ships npm >= 10.9.8.
         run: |
-          NPM_VERSION="11.9.0"
+          NPM_BOOTSTRAP_VERSION="10.9.8"
           NPM_DIR="$(dirname "$(dirname "$(which node)")")/lib/node_modules/npm"
           sudo rm -rf "${NPM_DIR}"
           sudo mkdir -p "${NPM_DIR}"
-          curl -fsSL "https://registry.npmjs.org/npm/-/npm-${NPM_VERSION}.tgz" | sudo tar -xz -C "${NPM_DIR}" --strip-components=1
+          curl -fsSL "https://registry.npmjs.org/npm/-/npm-${NPM_BOOTSTRAP_VERSION}.tgz" | sudo tar -xz -C "${NPM_DIR}" --strip-components=1
+          npm install -g npm@^11.6
           npm --version
 
       - name: Install dependencies
@@ -371,7 +374,6 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: "" # See https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
       - name: Update lock file


### PR DESCRIPTION
## Summary
- The Release workflow was failing on `npm install -g npm@^11.6` because the pre-installed npm 10.9.x on the Node 22 runner image ships with a broken `@npmcli/arborist` (missing `promise-retry`), which crashes during reify.
- Replace the global install with a tarball extract into the Node toolcache's `node_modules/npm`, pinned to npm 11.9.0. npm 11+ is still required for OIDC trusted publishing (`NPM_TOKEN: ""`).

## Test plan
- [ ] Merge and verify the next Release run passes the Update npm step