### PR TITLE
Force npm self-install in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,7 +345,7 @@ jobs:
 
       - name: Update npm
         run: |
-          npm install -g npm@^11.6
+          npm install -g --force npm@^11.6
           npm --version
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- The release workflow's \"Update npm\" step was failing with \`Cannot find module 'promise-retry'\` when upgrading the npm bundled with Node 22 (10.x) to 11.6. This is a known npm self-install bug ([failed run](https://github.com/e2b-dev/code-interpreter/actions/runs/24533700253/job/72475841925)).
- Adding \`--force\` to \`npm install -g npm@^11.6\` works around the module-resolution failure during the self-overwrite.

## Test plan
- [ ] Next run of the Release workflow reaches the \"Install dependencies\" step without erroring in \"Update npm\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)