### PR TITLE
Use Node 24 for release job to get npm 11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,10 +331,10 @@ jobs:
         with:
           version: 9.5
 
-      - name: Setup Node.js 22
+      - name: Setup Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
 
@@ -342,11 +342,6 @@ jobs:
         run: |
           pnpm config set auto-install-peers true
           pnpm config set exclude-links-from-lockfile true
-
-      - name: Update npm
-        run: |
-          npm install -g --force npm@^11.6
-          npm --version
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,7 +345,7 @@ jobs:
 
       - name: Update npm
         run: |
-          npm install -g npm@^11.6
+          npm install -g --force npm@^11.6
           npm --version
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
PR #258 didn't fix the release workflow — \`--force\` still crashed with \`Cannot find module 'promise-retry'\` ([failed run](https://github.com/e2b-dev/code-interpreter/actions/runs/24849240554/job/72746513559)) because the Node 22 tool cache's bundled npm is broken before any flag takes effect.

Switching the release job to Node 24.x (which ships with npm 11.12) lets us drop the \"Update npm\" step entirely while still satisfying the OIDC/provenance publish requirement.

## Test plan
- [ ] Next run of the Release workflow reaches \"Install dependencies\" and publishes without touching the \"Update npm\" step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)