### PR TITLE
Fix Python package name in changesets

### DIFF
--- a/.changeset/add-language-overloads.md
+++ b/.changeset/add-language-overloads.md
@@ -1,6 +1,6 @@
 ---
 "@e2b/code-interpreter": patch
-"e2b-code-interpreter": patch
+"@e2b/code-interpreter-python": patch
 ---
 
 Add autocomplete support for javascript, typescript, r, java, and bash languages in runCode/run_code and createCodeContext/create_code_context

--- a/.changeset/update-e2b-sdk-minimums.md
+++ b/.changeset/update-e2b-sdk-minimums.md
@@ -1,6 +1,6 @@
 ---
 "@e2b/code-interpreter": patch
-"e2b-code-interpreter": patch
+"@e2b/code-interpreter-python": patch
 ---
 
 Raise the minimum supported e2b SDK dependency versions.


### PR DESCRIPTION
Fix pending changesets to reference `@e2b/code-interpreter-python` instead of the PyPI package name `e2b-code-interpreter`.

Changesets resolves package names from pnpm workspace `package.json` files, not `pyproject.toml`, so the old name caused release planning to fail with “package e2b-code-interpreter is not in the workspace.”

it'll just combine the changesets, leaving the old one in should be fine. i think it autodeletes so there's possibly some missing changesets that never deployed we might lose in the change logs.
