### PR TITLE
docs: fix word order in python/README.md and js/README.md

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -13,7 +13,7 @@
 <img width="100%" src="/readme-assets/preview.png" alt="Cover image">
 --->
 ## What is E2B?
-[E2B](https://www.e2b.dev/) is an open-source infrastructure that allows you run to AI-generated code in secure isolated sandboxes in the cloud. To start and control sandboxes, use our [JavaScript SDK](https://www.npmjs.com/package/@e2b/code-interpreter) or [Python SDK](https://pypi.org/project/e2b_code_interpreter).
+[E2B](https://www.e2b.dev/) is an open-source infrastructure that allows you to run AI-generated code in secure isolated sandboxes in the cloud. To start and control sandboxes, use our [JavaScript SDK](https://www.npmjs.com/package/@e2b/code-interpreter) or [Python SDK](https://pypi.org/project/e2b_code_interpreter).
 
 ## Run your first Sandbox
 

--- a/python/README.md
+++ b/python/README.md
@@ -13,7 +13,7 @@
 <img width="100%" src="/readme-assets/preview.png" alt="Cover image">
 --->
 ## What is E2B?
-[E2B](https://www.e2b.dev/) is an open-source infrastructure that allows you run to AI-generated code in secure isolated sandboxes in the cloud. To start and control sandboxes, use our [JavaScript SDK](https://www.npmjs.com/package/@e2b/code-interpreter) or [Python SDK](https://pypi.org/project/e2b_code_interpreter).
+[E2B](https://www.e2b.dev/) is an open-source infrastructure that allows you to run AI-generated code in secure isolated sandboxes in the cloud. To start and control sandboxes, use our [JavaScript SDK](https://www.npmjs.com/package/@e2b/code-interpreter) or [Python SDK](https://pypi.org/project/e2b_code_interpreter).
 
 ## Run your first Sandbox
 


### PR DESCRIPTION
## What

Both `python/README.md` (line 16) and `js/README.md` (line 16) had the same word-order bug in the opening paragraph:

```diff
- [E2B] is an open-source infrastructure that allows you run to AI-generated code ...
+ [E2B] is an open-source infrastructure that allows you to run AI-generated code ...
```

The root `README.md` (line 23) already has the correct wording, so the two SDK-level READMEs were the outliers.

## Why this matters

These per-SDK READMEs are what PyPI and npm display as the package long description. So this typo is the first thing developers see when they land on:

- https://pypi.org/project/e2b_code_interpreter/
- https://www.npmjs.com/package/@e2b/code-interpreter

Fixing it is a one-line polish that cleans up the public landing page on both registries.

## How to test

```bash
$ grep -n "allows you" README.md python/README.md js/README.md
README.md:23:... allows you to run AI-generated code ...
js/README.md:16:... allows you to run AI-generated code ...
python/README.md:16:... allows you to run AI-generated code ...
```

All three READMEs now match.