### PR TITLE
Bump e2b SDK dependencies to latest

### DIFF
--- a/.changeset/bump-e2b-deps.md
+++ b/.changeset/bump-e2b-deps.md
@@ -1,6 +1,6 @@
 ---
 "@e2b/code-interpreter": patch
-"e2b-code-interpreter": patch
+"@e2b/code-interpreter-python": patch
 ---
 
 Raise the minimum supported e2b SDK dependency versions.

--- a/.changeset/bump-e2b-deps.md
+++ b/.changeset/bump-e2b-deps.md
@@ -1,0 +1,6 @@
+---
+"@e2b/code-interpreter": patch
+"e2b-code-interpreter": patch
+---
+
+Raise the minimum supported e2b SDK dependency versions.

--- a/js/package.json
+++ b/js/package.json
@@ -71,6 +71,6 @@
     "defaults"
   ],
   "dependencies": {
-    "e2b": "^2.19.2"
+    "e2b": "^2.19.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
   js:
     dependencies:
       e2b:
-        specifier: ^2.19.2
-        version: 2.19.2
+        specifier: ^2.19.4
+        version: 2.19.4
     devDependencies:
       '@types/node':
         specifier: ^20.19.19
@@ -987,8 +987,8 @@ packages:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
 
-  e2b@2.19.2:
-    resolution: {integrity: sha512-AJtaQ72XIjdOBGnsvzVuYveYmy4ZDALLzZddN7sFIgd49eCY7u7Nwx7TXp97vZLPTEgfCwEqn1U9mehDrQMp3g==}
+  e2b@2.19.4:
+    resolution: {integrity: sha512-9RefLykkjzVu+kUQfX5RxBonmZb08jcXIrRCRmZ8zutbG2bKV6PPyhV9O7mcyB1ZVHHO9UD2G8Z0VtY0lC+AAQ==}
     engines: {node: '>=20'}
 
   easy-table@1.2.0:
@@ -2660,7 +2660,7 @@ snapshots:
 
   dotenv@16.6.1: {}
 
-  e2b@2.19.2:
+  e2b@2.19.4:
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@connectrpc/connect': 2.0.0-rc.3(@bufbuild/protobuf@2.11.0)

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -186,13 +186,13 @@ files = [
 
 [[package]]
 name = "e2b"
-version = "2.20.2"
+version = "2.20.3"
 description = "E2B SDK that give agents cloud environments"
 optional = false
 python-versions = "<4.0,>=3.10"
 files = [
-    {file = "e2b-2.20.2-py3-none-any.whl", hash = "sha256:8ef964a4d1204a9fd61f4499662175a7a98ad173a81e7e848961799f77750276"},
-    {file = "e2b-2.20.2.tar.gz", hash = "sha256:ce69f65e0b07c1002ac4e386d109e4e658575efb2a774aefced92393f2cb2388"},
+    {file = "e2b-2.20.3-py3-none-any.whl", hash = "sha256:46c6b5ffc45c9ca6dc270dd4d29427cef6a2600c55a895565657ff2bedc06303"},
+    {file = "e2b-2.20.3.tar.gz", hash = "sha256:c6e91f71946755e1579b4ca1e175819d9f174b932b92e115cf36c2fd04674f3c"},
 ]
 
 [package.dependencies]
@@ -1060,4 +1060,4 @@ bracex = ">=2.1.1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "d6fbf63c1a861953087c36c747f986bda24374c8b74e4159c4e8653ee42c8cdb"
+content-hash = "85967515c3cebeb03c66f25c9dcd1efa143f086d5106dfbd0233d609745e0ada"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -14,7 +14,7 @@ python = "^3.10"
 
 httpx = ">=0.20.0, <1.0.0"
 attrs = ">=21.3.0"
-e2b = "^2.20.2"
+e2b = "^2.20.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.0"


### PR DESCRIPTION
## Summary
- Bump npm `e2b` minimum from `^2.19.2` to `^2.19.4` (latest on npm).
- Bump PyPI `e2b` minimum from `^2.20.2` to `^2.20.3` (latest on PyPI).
- Add a changeset to mark both `@e2b/code-interpreter` and `e2b-code-interpreter` for a patch release.

## Test plan
- [ ] CI green