### PR TITLE
Apply cwd to bash kernel contexts

### DIFF
--- a/.changeset/bash-cwd.md
+++ b/.changeset/bash-cwd.md
@@ -1,0 +1,5 @@
+---
+'@e2b/code-interpreter-template': patch
+---
+
+Apply cwd to bash kernel contexts (previously ignored, so `pwd` returned `/` regardless of the requested working directory)

--- a/js/tests/cwd.test.ts
+++ b/js/tests/cwd.test.ts
@@ -40,3 +40,10 @@ sandboxTest.skipIf(isDebug)('cwd java', async ({ sandbox }) => {
   })
   expect(result.results[0]?.text.trim()).toEqual('/home/user')
 })
+
+sandboxTest.skipIf(isDebug)('cwd bash', async ({ sandbox }) => {
+  const result = await sandbox.runCode('pwd', {
+    language: 'bash',
+  })
+  expect(result.logs.stdout.join().trim()).toEqual('/home/user')
+})

--- a/python/tests/async/test_async_cwd.py
+++ b/python/tests/async/test_async_cwd.py
@@ -33,3 +33,9 @@ async def test_cwd_java(async_sandbox: AsyncSandbox):
         'System.getProperty("user.dir")', language="java"
     )
     assert result.results[0].text.strip() == "/home/user"
+
+
+@pytest.mark.skip_debug()
+async def test_cwd_bash(async_sandbox: AsyncSandbox):
+    result = await async_sandbox.run_code("pwd", language="bash")
+    assert "".join(result.logs.stdout).strip() == "/home/user"

--- a/python/tests/sync/test_cwd.py
+++ b/python/tests/sync/test_cwd.py
@@ -31,3 +31,9 @@ def test_cwd_r(sandbox: Sandbox):
 def test_cwd_java(sandbox: Sandbox):
     result = sandbox.run_code('System.getProperty("user.dir")', language="java")
     assert result.results[0].text.strip() == "/home/user"
+
+
+@pytest.mark.skip_debug()
+def test_cwd_bash(sandbox: Sandbox):
+    result = sandbox.run_code("pwd", language="bash")
+    assert "".join(result.logs.stdout).strip() == "/home/user"

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -305,7 +305,7 @@ class ContextWebSocket:
                 message_id, f'System.setProperty("user.dir", "{path}");', True
             )
         elif language == "bash":
-            request = self._get_execute_request(message_id, f"cd {path}", True)
+            request = self._get_execute_request(message_id, f"cd '{path}'", True)
         else:
             return
 

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -304,6 +304,8 @@ class ContextWebSocket:
             request = self._get_execute_request(
                 message_id, f'System.setProperty("user.dir", "{path}");', True
             )
+        elif language == "bash":
+            request = self._get_execute_request(message_id, f"cd {path}", True)
         else:
             return
 


### PR DESCRIPTION
## Summary
- `change_current_directory` in `template/server/messaging.py` handled python, javascript/typescript, r, and java but fell through to a no-op for bash, so a context created with a non-default `cwd` still returned `/` from `pwd`.
- Added a bash branch that sends `cd <path>` to the kernel, plus bash cwd tests across sync/async Python and JS suites (the gap that let this regression slip in).
- Changeset: patch bump for `@e2b/code-interpreter-template`.

Refs: https://github.com/e2b-dev/E2B/issues/1318

🤖 Generated with [Claude Code](https://claude.com/claude-code)