### PR TITLE
perf(template): defer heavy imports and JS kernel to first use

### DIFF
--- a/template/server/main.py
+++ b/template/server/main.py
@@ -41,11 +41,6 @@ async def lifespan(app: FastAPI):
         default_websockets["python"] = python_context.id
         websockets["default"] = websockets[python_context.id]
 
-        javascript_context = await create_context(
-            client, websockets, "javascript", "/home/user"
-        )
-        default_websockets["javascript"] = javascript_context.id
-
         logger.info("Connected to default runtime")
         yield
 

--- a/template/startup_scripts/0002_data.py
+++ b/template/startup_scripts/0002_data.py
@@ -1,32 +1,6 @@
-import pandas
-from matplotlib.pyplot import Figure
 import IPython
 from IPython.core.formatters import BaseFormatter, JSONFormatter
 from traitlets.traitlets import Unicode, ObjectName
-
-from e2b_charts import chart_figure_to_dict
-import orjson
-
-
-def _figure_repr_e2b_chart_(self: Figure):
-    """
-    This method is used to extract data from the figure object to a dictionary
-    """
-    # Get all Axes objects from the Figure
-    try:
-        return chart_figure_to_dict(self)
-    except:  # noqa: E722
-        return {}
-
-
-def _dataframe_repr_e2b_data_(self: pandas.DataFrame):
-    result = self.to_dict(orient="list")
-    for key, value in result.items():
-        # Check each column's values
-        result[key] = [
-            v.isoformat() if isinstance(v, pandas.Timestamp) else v for v in value
-        ]
-    return result
 
 
 class E2BDataFormatter(BaseFormatter):
@@ -35,7 +9,19 @@ class E2BDataFormatter(BaseFormatter):
     print_method = ObjectName("_repr_e2b_data_")
     _return_type = (dict, str)
 
-    type_printers = {pandas.DataFrame: _dataframe_repr_e2b_data_}
+    def __call__(self, obj):
+        import pandas
+
+        if not isinstance(obj, pandas.DataFrame):
+            return super().__call__(obj)
+
+        result = obj.to_dict(orient="list")
+        for key, value in result.items():
+            # Check each column's values
+            result[key] = [
+                v.isoformat() if isinstance(v, pandas.Timestamp) else v for v in value
+            ]
+        return result
 
 
 class E2BChartFormatter(BaseFormatter):
@@ -48,9 +34,13 @@ class E2BChartFormatter(BaseFormatter):
         # Figure object is for some reason removed on execution of the cell,
         # so it can't be used in type_printers or with top-level import
         from matplotlib.pyplot import Figure
+        from e2b_charts import chart_figure_to_dict
 
         if isinstance(obj, Figure):
-            return _figure_repr_e2b_chart_(obj)
+            try:
+                return chart_figure_to_dict(obj)
+            except:  # noqa: E722
+                return {}
         return super().__call__(obj)
 
 
@@ -58,6 +48,8 @@ class E2BJSONFormatter(JSONFormatter):
     def __call__(self, obj):
         if isinstance(obj, (list, dict)):
             try:
+                import orjson
+
                 return orjson.loads(
                     orjson.dumps(
                         obj, option=orjson.OPT_SERIALIZE_NUMPY | orjson.OPT_NON_STR_KEYS


### PR DESCRIPTION
The Python kernel's IPython startup script (template/startup_scripts/0002_data.py)
imported pandas, matplotlib, e2b_charts, and orjson at module load time, and the
FastAPI server's lifespan spawned a JavaScript context (Node + ijavascript)
on boot. Both costs were paid by every Python kernel and every server start —
even by customers who never displayed a DataFrame, rendered a chart, or ran
any JavaScript code.

This PR moves both behind first-use:

- **0002_data.py**: heavy imports moved inside formatter `__call__` bodies.
  Top-level imports are now just IPython + traitlets. `E2BDataFormatter`
  dispatches via `isinstance()` instead of `type_printers={pandas.DataFrame: ...}`,
  which avoided pulling pandas in at class-definition time.

- **server/main.py**: `lifespan` no longer creates the JavaScript context.
  The existing `/execute` handler already lazy-creates a context when
  `default_websockets` has no entry for the requested language (the same path
  that already handled TypeScript), so the JS kernel is now spawned on the
  first `/execute` with `language=javascript`. The Python context stays eager
  because it backs `websockets["default"]`.