### PR TITLE
Fix kernel interrupt on client disconnect with FastAPI 0.136.3

### DIFF
--- a/.changeset/interrupt-on-disconnect-fastapi.md
+++ b/.changeset/interrupt-on-disconnect-fastapi.md
@@ -1,0 +1,5 @@
+---
+'@e2b/code-interpreter-template': patch
+---
+
+Interrupt the kernel when the HTTP client disconnects mid-execution so the per-context lock is released and subsequent executions aren't blocked (#213). On the latest FastAPI (0.136.3) / Starlette (1.2.1), `StreamingResponse` no longer cancels the response body iterator on `http.disconnect` (ASGI spec 2.4+), so the server now detects the disconnect itself by polling `request.is_disconnected()` while streaming and interrupts the kernel.

--- a/template/server/main.py
+++ b/template/server/main.py
@@ -123,6 +123,7 @@ async def post_execute(request: Request, exec_request: ExecutionRequest):
             exec_request.code,
             env_vars=exec_request.env_vars,
             access_token=request.headers.get("X-Access-Token", None),
+            request=request,
         )
     )
 

--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -13,6 +13,7 @@ from typing import (
     Union,
 )
 from pydantic import StrictStr
+from starlette.requests import Request
 from websockets.client import WebSocketClientProtocol, connect
 from websockets.exceptions import (
     ConnectionClosedError,
@@ -37,6 +38,10 @@ logger = logging.getLogger(__name__)
 MAX_RECONNECT_RETRIES = 3
 PING_TIMEOUT = 30
 KEEPALIVE_INTERVAL = 5  # seconds between keepalive pings during streaming
+
+
+class _ClientDisconnected(Exception):
+    """Raised internally when the HTTP client disconnects mid-execution (#213)."""
 
 
 class Execution:
@@ -251,26 +256,28 @@ class ContextWebSocket:
         finally:
             del self._executions[message_id]
 
-    async def _wait_for_result(self, message_id: str):
+    async def _wait_for_result(
+        self, message_id: str, request: Optional[Request] = None
+    ):
         queue = self._executions[message_id].queue
 
-        # Use a timeout on queue.get() to periodically send keepalives.
-        # Without keepalives, the generator blocks indefinitely waiting for
-        # kernel output. If the client silently disappears (e.g. network
-        # failure), uvicorn can only detect the broken connection when it
-        # tries to write — so we force a write every KEEPALIVE_INTERVAL
-        # seconds. This ensures timely disconnect detection and kernel
-        # interrupt for abandoned executions (see #213).
+        # Wait with a timeout so that, even when the kernel emits no output, we
+        # periodically poll for client disconnects and write a keepalive. The
+        # latest Starlette no longer cancels this generator on disconnect, so
+        # an orphaned execution would otherwise keep holding self._lock (#213).
         while True:
             try:
                 output = await asyncio.wait_for(queue.get(), timeout=KEEPALIVE_INTERVAL)
             except asyncio.TimeoutError:
-                # Yield a keepalive so Starlette writes to the socket.
-                # If the client has disconnected, the write fails and
-                # uvicorn delivers http.disconnect, which cancels this
-                # generator via CancelledError.
+                if request is not None and await request.is_disconnected():
+                    raise _ClientDisconnected()
                 yield {"type": "keepalive"}
                 continue
+
+            # Also check before forwarding output, in case the client left
+            # while the kernel was actively streaming.
+            if request is not None and await request.is_disconnected():
+                raise _ClientDisconnected()
 
             if output.type == OutputType.END_OF_EXECUTION:
                 break
@@ -320,6 +327,7 @@ class ContextWebSocket:
         code: Union[str, StrictStr],
         env_vars: Dict[StrictStr, str],
         access_token: str,
+        request: Optional[Request] = None,
     ):
         if self._ws is None:
             raise Exception("WebSocket not connected")
@@ -368,10 +376,12 @@ class ContextWebSocket:
                     logger.info(
                         f"Sending code for the execution ({message_id}): {complete_code}"
                     )
-                    request = self._get_execute_request(
+                    # Don't rebind `request`: it holds the Starlette Request
+                    # we poll for disconnects below (#213).
+                    execute_request = self._get_execute_request(
                         message_id, complete_code, False
                     )
-                    await self._ws.send(request)
+                    await self._ws.send(execute_request)
                     break
                 except (ConnectionClosedError, WebSocketException) as e:
                     # Keep the last result, even if error
@@ -392,22 +402,27 @@ class ContextWebSocket:
                 )
                 await execution.queue.put(UnexpectedEndOfExecution())
 
-            # Stream the results.
-            # If the client disconnects (Starlette cancels the task), we
-            # interrupt the kernel so the next execution isn't blocked (#213).
+            # Stream the results. On client disconnect we interrupt the kernel
+            # so the lock is released and the next execution isn't blocked
+            # (#213). The disconnect surfaces either as _ClientDisconnected
+            # (latest Starlette, raised by _wait_for_result) or as
+            # CancelledError/GeneratorExit (older Starlette / generator teardown).
             try:
-                async for item in self._wait_for_result(message_id):
+                async for item in self._wait_for_result(message_id, request=request):
                     yield item
-            except (asyncio.CancelledError, GeneratorExit):
+            except (asyncio.CancelledError, GeneratorExit, _ClientDisconnected) as e:
                 logger.warning(
                     f"Client disconnected during execution ({message_id}), interrupting kernel"
                 )
-                # Shield the interrupt from the ongoing cancellation so
-                # the HTTP request to the kernel actually completes.
+                # Shield so the interrupt completes even if we're being cancelled.
                 try:
                     await asyncio.shield(self.interrupt())
                 except asyncio.CancelledError:
                     pass
+                # We detected the disconnect ourselves: unwind cleanly so the
+                # lock releases. A real cancellation/teardown must propagate.
+                if isinstance(e, _ClientDisconnected):
+                    return
                 raise
             finally:
                 if message_id in self._executions:

--- a/template/server/requirements.txt
+++ b/template/server/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.111.0
+fastapi==0.136.3
 httpx==0.28.1
 websockets==12.0
 uvicorn[standard]==0.30.1


### PR DESCRIPTION
## What

Supersedes the Renovate bump #207 (`fastapi 0.111.0 → 0.136.3`), which fails CI, by including the dependency bump **plus** the fix it requires.

## The problem

PR #207 only bumps `fastapi==0.111.0` → `fastapi==0.136.3` in `template/server/requirements.txt`, yet **both** SDK jobs fail — on the same test:

- **js**: `tests/interrupt.test.ts > subsequent execution works after client timeout`
- **python**: `test_async_interrupt.py::test_subsequent_execution_works_after_client_timeout`

Both fail with a `TimeoutError`/`TimeoutException` on the *second* execution.

## Root cause

This is the **#213** behavior: when a client disconnects mid-execution, the server interrupts the kernel so the next execution isn't blocked. The interrupt relied on Starlette **cancelling the streaming response body iterator** on `http.disconnect`.

Bumping FastAPI `0.111.0` → `0.136.3` pulls **Starlette `0.37.2` → `1.2.1`**. Starlette ≥ 1.0 added a new `StreamingResponse.__call__` path for ASGI `spec_version >= (2, 4)` (which uvicorn 0.30.1 advertises):

```python
if spec_version >= (2, 4):
    try:
        await self.stream_response(send)   # no task group, no listen_for_disconnect
    except OSError:
        raise ClientDisconnect()
```

It no longer runs `listen_for_disconnect` concurrently and **no longer cancels the body iterator**. So the `execute()` generator never receives `CancelledError`/`GeneratorExit`, the kernel is never interrupted, and the abandoned `time.sleep(300)` blocks the next execution until it times out.

Verified empirically against `starlette==1.2.1` + `uvicorn==0.30.1`: on client disconnect the body generator is *not* cancelled, but `request.is_disconnected()` *does* flip to `True`.

## The fix

Detect the disconnect explicitly instead of relying on Starlette cancellation:

- Thread the `Request` into `ContextWebSocket.execute()`.
- On each keepalive tick in `_wait_for_result`, poll `request.is_disconnected()`. When it flips, raise an internal `_ClientDisconnected`.
- `execute()` catches it (alongside the existing `CancelledError`/`GeneratorExit` path for older Starlette), interrupts the kernel, and stops streaming gracefully.

End-to-end reproduction (uvicorn 0.30.1 + starlette 1.2.1, mirroring the real queue/keepalive/`StreamingListJsonResponse` structure) confirms the kernel is interrupted within ~1–2s of disconnect.

## Notes

- The fastapi 0.136 change "do not accept underscore headers" does not affect us — the only header read is `X-Access-Token` (hyphenated).
- `ruff check` / `ruff format` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)