### PR TITLE
Bump jupyter-server to 2.18.0 and pin root_dir

### DIFF
--- a/.changeset/cold-pillows-grow.md
+++ b/.changeset/cold-pillows-grow.md
@@ -1,0 +1,5 @@
+---
+"@e2b/code-interpreter-template": patch
+---
+
+Pin `jupyter-server` `root_dir` to `/home/user` so session creation keeps working with jupyter-server 2.18.0's path-traversal hardening

--- a/template/jupyter_server_config.py
+++ b/template/jupyter_server_config.py
@@ -3,6 +3,19 @@
 c = get_config()  # noqa
 
 
+# Pin the contents root directory.
+#
+#         Sessions are created with a relative path (a bare uuid, see
+#         server/contexts.py). Without an explicit root_dir, jupyter-server
+#         inherits the process working directory as its root — which is "/"
+#         under systemd (jupyter.service has no WorkingDirectory). Since
+#         jupyter-server 2.18.0 (CVE-2026-35397 path-traversal hardening), a
+#         root_dir of "/" makes every POST /api/sessions fail with
+#         "<uuid> is outside root contents directory", so the server never
+#         starts. Pinning it to /home/user matches the execution cwd.
+c.ServerApp.root_dir = "/home/user"
+
+
 # Set the Access-Control-Allow-Origin header
 #
 #          Use '*' to allow any origin to access your server.

--- a/template/requirements.txt
+++ b/template/requirements.txt
@@ -1,5 +1,5 @@
 # Jupyter server requirements
-jupyter-server==2.16.0
+jupyter-server==2.18.0
 ipykernel==6.31.0
 ipython==9.14.0
 


### PR DESCRIPTION
Supersedes #274 (dependabot bump of jupyter-server 2.16.0 → 2.18.0).

The straight dependency bump breaks the sandbox: jupyter-server 2.18.0 ships path-traversal hardening (CVE-2026-35397) that rejects session creation when the contents root resolves to `/` — which is the cwd of the systemd-launched process (`jupyter.service` has no `WorkingDirectory`). Every `POST /api/sessions` then fails with `<uuid> is outside root contents directory` and the server never serves.

This PR carries the same bump **plus** pins `c.ServerApp.root_dir = "/home/user"` in `template/jupyter_server_config.py` so sessions are created relative to the execution cwd.

## Changes
- Bump `jupyter-server` 2.16.0 → 2.18.0 (`template/requirements.txt`)
- Pin `root_dir` to `/home/user` (`template/jupyter_server_config.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)