### PR TITLE
docs: document building the template with build_prod.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,6 @@ Visit [E2B documentation](https://e2b.dev/docs).
 
 ### 5. E2B cookbook
 Visit our [Cookbook](https://github.com/e2b-dev/e2b-cookbook/tree/main) to get inspired by examples with different LLMs and AI frameworks.
+
+## Customizing the sandbox template
+Need extra packages or a different runtime? You can build your own Code Interpreter sandbox template. See the [template guide](/template/README.md) for a step-by-step walkthrough of creating, building, and using a custom template (as well as building the production `code-interpreter-v1` template).

--- a/template/README.md
+++ b/template/README.md
@@ -1,4 +1,4 @@
-# Using custom sandbox with Code Interpreter SDK
+# Customizing the Code Interpreter template
 
 If you want to customize the Code Interpreter sandbox (e.g.: add a preinstalled package) you can do that by creating a [custom sandbox template](https://e2b.dev/docs/template/quickstart).
 
@@ -40,13 +40,19 @@ Template.build(
 )
 ```
 
-3. Build the template:
+4. Set your environment variables in a `.env` file (loaded by `load_dotenv()`):
+
+```
+E2B_API_KEY=e2b_***
+```
+
+5. Build the template:
 
 ```
 python build.py
 ```
 
-4. Use the custom template:
+6. Use the custom template:
 
 ```python
 from e2b import Sandbox
@@ -54,6 +60,35 @@ from e2b import Sandbox
 sbx = Sandbox.create(template="code-interpreter-custom")
 execution = sbx.run_code("print('Hello, World!')")
 print(execution.logs.stdout)
+```
+
+## Building the production template
+
+To build the official `code-interpreter-v1` template from this repo, use
+`template/build_prod.py`. This is the script CI and releases run.
+
+1. Install the build dependencies:
+
+```
+pip install -r template/requirements-dev.txt
+```
+
+2. Provide your credentials in `template/.env`:
+
+```
+E2B_API_KEY=e2b_***
+```
+
+3. Build the template:
+
+```
+python template/build_prod.py
+```
+
+Set `SKIP_CACHE=true` to force a clean rebuild that ignores the layer cache:
+
+```
+SKIP_CACHE=true python template/build_prod.py
 ```
 
 ## Debugging a server that won't start

--- a/template/README.md
+++ b/template/README.md
@@ -3,7 +3,7 @@
 ## Building the production template
 
 To build the official `code-interpreter-v1` template from this repo, use
-`template/build_prod.py`. This is the script CI and releases run.
+`build_prod.py`. This is the script CI and releases run.
 
 1. Install the build dependencies:
 

--- a/template/README.md
+++ b/template/README.md
@@ -8,10 +8,10 @@ To build the official `code-interpreter-v1` template from this repo, use
 1. Install the build dependencies:
 
 ```
-pip install -r template/requirements-dev.txt
+pip install -r requirements-dev.txt
 ```
 
-2. Provide your credentials in `template/.env`:
+2. Provide your credentials in `.env`:
 
 ```
 E2B_API_KEY=e2b_***
@@ -20,13 +20,13 @@ E2B_API_KEY=e2b_***
 3. Build the template:
 
 ```
-python template/build_prod.py
+python build_prod.py
 ```
 
 Set `SKIP_CACHE=true` to force a clean rebuild that ignores the layer cache:
 
 ```
-SKIP_CACHE=true python template/build_prod.py
+SKIP_CACHE=true python build_prod.py
 ```
 
 If you want to customize the Code Interpreter sandbox (e.g.: add a preinstalled package) you can do that by creating a [custom sandbox template](https://e2b.dev/docs/template/quickstart).

--- a/template/README.md
+++ b/template/README.md
@@ -1,8 +1,37 @@
-# Customizing the Code Interpreter template
+# Code Interpreter
+
+## Building the production template
+
+To build the official `code-interpreter-v1` template from this repo, use
+`template/build_prod.py`. This is the script CI and releases run.
+
+1. Install the build dependencies:
+
+```
+pip install -r template/requirements-dev.txt
+```
+
+2. Provide your credentials in `template/.env`:
+
+```
+E2B_API_KEY=e2b_***
+```
+
+3. Build the template:
+
+```
+python template/build_prod.py
+```
+
+Set `SKIP_CACHE=true` to force a clean rebuild that ignores the layer cache:
+
+```
+SKIP_CACHE=true python template/build_prod.py
+```
 
 If you want to customize the Code Interpreter sandbox (e.g.: add a preinstalled package) you can do that by creating a [custom sandbox template](https://e2b.dev/docs/template/quickstart).
 
-## Step-by-step guide
+## Creating a custom template
 
 1. Install E2B SDK
 
@@ -60,35 +89,6 @@ from e2b import Sandbox
 sbx = Sandbox.create(template="code-interpreter-custom")
 execution = sbx.run_code("print('Hello, World!')")
 print(execution.logs.stdout)
-```
-
-## Building the production template
-
-To build the official `code-interpreter-v1` template from this repo, use
-`template/build_prod.py`. This is the script CI and releases run.
-
-1. Install the build dependencies:
-
-```
-pip install -r template/requirements-dev.txt
-```
-
-2. Provide your credentials in `template/.env`:
-
-```
-E2B_API_KEY=e2b_***
-```
-
-3. Build the template:
-
-```
-python template/build_prod.py
-```
-
-Set `SKIP_CACHE=true` to force a clean rebuild that ignores the layer cache:
-
-```
-SKIP_CACHE=true python template/build_prod.py
 ```
 
 ## Debugging a server that won't start


### PR DESCRIPTION
Documents how to build the E2B Code Interpreter template from this repo. Renames the customizing section to "Customizing the Code Interpreter template" and adds an explicit step for setting `E2B_API_KEY` in a `.env` file. Adds a new "Building the production template" section covering `template/build_prod.py`, installing `requirements-dev.txt`, and the `SKIP_CACHE=true` flag for clean rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)