### PR TITLE
Throw descriptive error when sandbox is killed mid-request

### DIFF
--- a/.changeset/grumpy-sloths-relax.md
+++ b/.changeset/grumpy-sloths-relax.md
@@ -1,0 +1,6 @@
+---
+'@e2b/code-interpreter': patch
+'@e2b/code-interpreter-python': patch
+---
+
+Throw a descriptive sandbox error instead of a raw socket error (e.g. `ECONNRESET`) when the sandbox is killed or times out while a request (`runCode`/`run_code`, context management) is in progress

--- a/.changeset/grumpy-sloths-relax.md
+++ b/.changeset/grumpy-sloths-relax.md
@@ -3,4 +3,4 @@
 '@e2b/code-interpreter-python': patch
 ---
 
-Throw a descriptive sandbox error instead of a raw socket error (e.g. `ECONNRESET`) when the sandbox is killed or times out while a request (`runCode`/`run_code`, context management) is in progress
+Throw a descriptive `TimeoutError`/`TimeoutException` instead of a raw socket error (e.g. `ECONNRESET`) when the sandbox is killed or times out while a request (`runCode`/`run_code`, context management) is in progress

--- a/js/src/sandbox.ts
+++ b/js/src/sandbox.ts
@@ -279,7 +279,7 @@ export class Sandbox extends BaseSandbox {
 
       return execution
     } catch (error) {
-      throw await this.formatRequestError(error)
+      throw await this.handleRequestError(error)
     }
   }
 
@@ -318,7 +318,7 @@ export class Sandbox extends BaseSandbox {
 
       return await res.json()
     } catch (error) {
-      throw await this.formatRequestError(error)
+      throw await this.handleRequestError(error)
     }
   }
 
@@ -354,7 +354,7 @@ export class Sandbox extends BaseSandbox {
         throw error
       }
     } catch (error) {
-      throw await this.formatRequestError(error)
+      throw await this.handleRequestError(error)
     }
   }
 
@@ -389,7 +389,7 @@ export class Sandbox extends BaseSandbox {
 
       return await res.json()
     } catch (error) {
-      throw await this.formatRequestError(error)
+      throw await this.handleRequestError(error)
     }
   }
 
@@ -425,7 +425,7 @@ export class Sandbox extends BaseSandbox {
         throw error
       }
     } catch (error) {
-      throw await this.formatRequestError(error)
+      throw await this.handleRequestError(error)
     }
   }
 
@@ -435,7 +435,7 @@ export class Sandbox extends BaseSandbox {
    * `TimeoutError`. Otherwise falls back to formatting request timeouts and
    * re-throwing the original error.
    */
-  private async formatRequestError(error: unknown): Promise<unknown> {
+  private async handleRequestError(error: unknown): Promise<unknown> {
     if (
       isConnectionClosedError(error) &&
       // If the state check itself fails we can't tell whether the sandbox

--- a/js/src/sandbox.ts
+++ b/js/src/sandbox.ts
@@ -1,4 +1,4 @@
-import { Sandbox as BaseSandbox, InvalidArgumentError, SandboxError } from 'e2b'
+import { Sandbox as BaseSandbox, InvalidArgumentError, TimeoutError } from 'e2b'
 
 import {
   Result,
@@ -435,7 +435,7 @@ export class Sandbox extends BaseSandbox {
   }
 
   /**
-   * Throws a descriptive `SandboxError` if the connection error was caused
+   * Throws a descriptive `TimeoutError` if the connection error was caused
    * by the sandbox being killed mid-request. If the sandbox is still running
    * (or its state can't be determined), returns so the caller can re-throw
    * the original error.
@@ -448,7 +448,7 @@ export class Sandbox extends BaseSandbox {
       // original error instead of wrongly claiming the sandbox is gone.
       (await this.isRunning().catch(() => true)) === false
     ) {
-      throw new SandboxError(
+      throw new TimeoutError(
         'The sandbox was killed while the request was in progress. This can happen when the sandbox times out or is killed manually. ' +
           "You can modify the sandbox timeout by passing 'timeoutMs' when starting the sandbox or calling '.setTimeout' on the sandbox with the desired timeout."
       )

--- a/js/src/sandbox.ts
+++ b/js/src/sandbox.ts
@@ -1,8 +1,4 @@
-import {
-  Sandbox as BaseSandbox,
-  InvalidArgumentError,
-  SandboxError,
-} from 'e2b'
+import { Sandbox as BaseSandbox, InvalidArgumentError, SandboxError } from 'e2b'
 
 import {
   Result,

--- a/js/src/sandbox.ts
+++ b/js/src/sandbox.ts
@@ -279,8 +279,7 @@ export class Sandbox extends BaseSandbox {
 
       return execution
     } catch (error) {
-      await this.throwIfSandboxKilled(error)
-      throw formatRequestTimeoutError(error)
+      throw await this.formatRequestError(error)
     }
   }
 
@@ -319,8 +318,7 @@ export class Sandbox extends BaseSandbox {
 
       return await res.json()
     } catch (error) {
-      await this.throwIfSandboxKilled(error)
-      throw formatRequestTimeoutError(error)
+      throw await this.formatRequestError(error)
     }
   }
 
@@ -356,8 +354,7 @@ export class Sandbox extends BaseSandbox {
         throw error
       }
     } catch (error) {
-      await this.throwIfSandboxKilled(error)
-      throw formatRequestTimeoutError(error)
+      throw await this.formatRequestError(error)
     }
   }
 
@@ -392,8 +389,7 @@ export class Sandbox extends BaseSandbox {
 
       return await res.json()
     } catch (error) {
-      await this.throwIfSandboxKilled(error)
-      throw formatRequestTimeoutError(error)
+      throw await this.formatRequestError(error)
     }
   }
 
@@ -429,29 +425,30 @@ export class Sandbox extends BaseSandbox {
         throw error
       }
     } catch (error) {
-      await this.throwIfSandboxKilled(error)
-      throw formatRequestTimeoutError(error)
+      throw await this.formatRequestError(error)
     }
   }
 
   /**
-   * Throws a descriptive `TimeoutError` if the connection error was caused
-   * by the sandbox being killed mid-request. If the sandbox is still running
-   * (or its state can't be determined), returns so the caller can re-throw
-   * the original error.
+   * Returns the error to throw for a failed request. If the connection was
+   * closed because the sandbox was killed mid-request, returns a descriptive
+   * `TimeoutError`. Otherwise falls back to formatting request timeouts and
+   * re-throwing the original error.
    */
-  private async throwIfSandboxKilled(error: unknown): Promise<void> {
+  private async formatRequestError(error: unknown): Promise<unknown> {
     if (
       isConnectionClosedError(error) &&
       // If the state check itself fails we can't tell whether the sandbox
-      // was killed — assume it's running so the caller re-throws the
-      // original error instead of wrongly claiming the sandbox is gone.
+      // was killed — assume it's running so we re-throw the original error
+      // instead of wrongly claiming the sandbox is gone.
       (await this.isRunning().catch(() => true)) === false
     ) {
-      throw new TimeoutError(
+      return new TimeoutError(
         'The sandbox was killed while the request was in progress. This can happen when the sandbox times out or is killed manually. ' +
           "You can modify the sandbox timeout by passing 'timeoutMs' when starting the sandbox or calling '.setTimeout' on the sandbox with the desired timeout."
       )
     }
+
+    return formatRequestTimeoutError(error)
   }
 }

--- a/js/src/sandbox.ts
+++ b/js/src/sandbox.ts
@@ -1,4 +1,8 @@
-import { Sandbox as BaseSandbox, InvalidArgumentError } from 'e2b'
+import {
+  Sandbox as BaseSandbox,
+  InvalidArgumentError,
+  SandboxError,
+} from 'e2b'
 
 import {
   Result,
@@ -11,6 +15,7 @@ import {
 import {
   formatExecutionTimeoutError,
   formatRequestTimeoutError,
+  isConnectionClosedError,
   readLines,
 } from './utils'
 import { JUPYTER_PORT, DEFAULT_TIMEOUT_MS } from './consts'
@@ -278,6 +283,7 @@ export class Sandbox extends BaseSandbox {
 
       return execution
     } catch (error) {
+      await this.throwIfSandboxKilled(error)
       throw formatRequestTimeoutError(error)
     }
   }
@@ -317,6 +323,7 @@ export class Sandbox extends BaseSandbox {
 
       return await res.json()
     } catch (error) {
+      await this.throwIfSandboxKilled(error)
       throw formatRequestTimeoutError(error)
     }
   }
@@ -353,6 +360,7 @@ export class Sandbox extends BaseSandbox {
         throw error
       }
     } catch (error) {
+      await this.throwIfSandboxKilled(error)
       throw formatRequestTimeoutError(error)
     }
   }
@@ -388,6 +396,7 @@ export class Sandbox extends BaseSandbox {
 
       return await res.json()
     } catch (error) {
+      await this.throwIfSandboxKilled(error)
       throw formatRequestTimeoutError(error)
     }
   }
@@ -424,7 +433,29 @@ export class Sandbox extends BaseSandbox {
         throw error
       }
     } catch (error) {
+      await this.throwIfSandboxKilled(error)
       throw formatRequestTimeoutError(error)
+    }
+  }
+
+  /**
+   * Throws a descriptive `SandboxError` if the connection error was caused
+   * by the sandbox being killed mid-request. If the sandbox is still running
+   * (or its state can't be determined), returns so the caller can re-throw
+   * the original error.
+   */
+  private async throwIfSandboxKilled(error: unknown): Promise<void> {
+    if (
+      isConnectionClosedError(error) &&
+      // If the state check itself fails we can't tell whether the sandbox
+      // was killed — assume it's running so the caller re-throws the
+      // original error instead of wrongly claiming the sandbox is gone.
+      (await this.isRunning().catch(() => true)) === false
+    ) {
+      throw new SandboxError(
+        'The sandbox was killed while the request was in progress. This can happen when the sandbox times out or is killed manually. ' +
+          "You can modify the sandbox timeout by passing 'timeoutMs' when starting the sandbox or calling '.setTimeout' on the sandbox with the desired timeout."
+      )
     }
   }
 }

--- a/js/src/utils.ts
+++ b/js/src/utils.ts
@@ -20,6 +20,35 @@ export function formatExecutionTimeoutError(error: unknown) {
   return error
 }
 
+const CONNECTION_CLOSED_CODES = ['ECONNRESET', 'EPIPE', 'UND_ERR_SOCKET']
+
+/**
+ * Checks if the error means the connection was closed/reset while the request
+ * was in flight. The shape of this error is runtime-specific — Bun and Deno
+ * set a `code` directly, while Node's fetch (undici) wraps the socket error
+ * in the `cause` of a generic `TypeError`.
+ */
+export function isConnectionClosedError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+
+  const code = (error as { code?: unknown }).code
+  if (typeof code === 'string' && CONNECTION_CLOSED_CODES.includes(code)) {
+    return true
+  }
+
+  if (error.name === 'ConnectionReset' || error.name === 'ConnectionClosed') {
+    return true
+  }
+
+  if (error.cause) {
+    return isConnectionClosedError(error.cause)
+  }
+
+  return false
+}
+
 export async function* readLines(stream: ReadableStream<Uint8Array>) {
   const reader = stream.getReader()
   let buffer = ''

--- a/js/tests/killedSandbox.test.ts
+++ b/js/tests/killedSandbox.test.ts
@@ -1,0 +1,18 @@
+import { expect } from 'vitest'
+
+import { isDebug, sandboxTest, wait } from './setup'
+
+sandboxTest.skipIf(isDebug)(
+  'runCode throws a descriptive error when the sandbox is killed during execution',
+  async ({ sandbox }) => {
+    const execution = sandbox.runCode('import time; time.sleep(60)')
+    const assertion = expect(execution).rejects.toThrowError(
+      /sandbox was killed while the request was in progress/
+    )
+
+    await wait(2_000)
+    await sandbox.kill()
+
+    await assertion
+  }
+)

--- a/js/tests/killedSandbox.test.ts
+++ b/js/tests/killedSandbox.test.ts
@@ -1,3 +1,4 @@
+import { TimeoutError } from 'e2b'
 import { expect } from 'vitest'
 
 import { isDebug, sandboxTest, wait } from './setup'
@@ -6,9 +7,12 @@ sandboxTest.skipIf(isDebug)(
   'runCode throws a descriptive error when the sandbox is killed during execution',
   async ({ sandbox }) => {
     const execution = sandbox.runCode('import time; time.sleep(60)')
-    const assertion = expect(execution).rejects.toThrowError(
-      /sandbox was killed while the request was in progress/
-    )
+    const assertion = Promise.all([
+      expect(execution).rejects.toThrowError(
+        /sandbox was killed while the request was in progress/
+      ),
+      expect(execution).rejects.toBeInstanceOf(TimeoutError),
+    ])
 
     await wait(2_000)
     await sandbox.kill()

--- a/js/tests/killedSandbox.test.ts
+++ b/js/tests/killedSandbox.test.ts
@@ -6,7 +6,14 @@ import { isDebug, sandboxTest, wait } from './setup'
 sandboxTest.skipIf(isDebug)(
   'runCode throws a descriptive error when the sandbox is killed during execution',
   async ({ sandbox }) => {
-    const execution = sandbox.runCode('import time; time.sleep(60)')
+    // Keep the execution firmly in-flight until the kill: the sleep is far
+    // longer than the kill delay and the execution timeout is pushed well
+    // beyond the kill + disconnect-detection window, so the only thing that
+    // ends the request is the sandbox being killed (not a body-timer abort
+    // or the sleep completing on its own).
+    const execution = sandbox.runCode('import time; time.sleep(300)', {
+      timeoutMs: 300_000,
+    })
     const assertion = Promise.all([
       expect(execution).rejects.toThrowError(
         /sandbox was killed while the request was in progress/
@@ -18,5 +25,6 @@ sandboxTest.skipIf(isDebug)(
     await sandbox.kill()
 
     await assertion
-  }
+  },
+  60_000
 )

--- a/python/e2b_code_interpreter/code_interpreter_async.py
+++ b/python/e2b_code_interpreter/code_interpreter_async.py
@@ -84,7 +84,7 @@ class AsyncSandbox(BaseAsyncSandbox):
             transport=get_transport(self.connection_config, http2=False),
         )
 
-    async def _raise_if_sandbox_killed(self, err: Exception) -> None:
+    async def _handle_connection_error(self, err: Exception) -> None:
         """
         Raises a descriptive exception if the connection error was caused by
         the sandbox being killed mid-request. If the sandbox is still running
@@ -236,7 +236,7 @@ class AsyncSandbox(BaseAsyncSandbox):
         except httpx.TimeoutException:
             raise format_request_timeout_error()
         except (httpx.ReadError, httpx.RemoteProtocolError) as err:
-            await self._raise_if_sandbox_killed(err)
+            await self._handle_connection_error(err)
             raise
 
     async def create_code_context(
@@ -285,7 +285,7 @@ class AsyncSandbox(BaseAsyncSandbox):
         except httpx.TimeoutException:
             raise format_request_timeout_error()
         except (httpx.ReadError, httpx.RemoteProtocolError) as err:
-            await self._raise_if_sandbox_killed(err)
+            await self._handle_connection_error(err)
             raise
 
     async def remove_code_context(
@@ -320,7 +320,7 @@ class AsyncSandbox(BaseAsyncSandbox):
         except httpx.TimeoutException:
             raise format_request_timeout_error()
         except (httpx.ReadError, httpx.RemoteProtocolError) as err:
-            await self._raise_if_sandbox_killed(err)
+            await self._handle_connection_error(err)
             raise
 
     async def list_code_contexts(self) -> List[Context]:
@@ -351,7 +351,7 @@ class AsyncSandbox(BaseAsyncSandbox):
         except httpx.TimeoutException:
             raise format_request_timeout_error()
         except (httpx.ReadError, httpx.RemoteProtocolError) as err:
-            await self._raise_if_sandbox_killed(err)
+            await self._handle_connection_error(err)
             raise
 
     async def restart_code_context(
@@ -385,5 +385,5 @@ class AsyncSandbox(BaseAsyncSandbox):
         except httpx.TimeoutException:
             raise format_request_timeout_error()
         except (httpx.ReadError, httpx.RemoteProtocolError) as err:
-            await self._raise_if_sandbox_killed(err)
+            await self._handle_connection_error(err)
             raise

--- a/python/e2b_code_interpreter/code_interpreter_async.py
+++ b/python/e2b_code_interpreter/code_interpreter_async.py
@@ -29,6 +29,7 @@ from e2b_code_interpreter.models import (
 from e2b_code_interpreter.exceptions import (
     format_execution_timeout_error,
     format_request_timeout_error,
+    format_sandbox_killed_error,
 )
 
 logger = logging.getLogger(__name__)
@@ -82,6 +83,23 @@ class AsyncSandbox(BaseAsyncSandbox):
         return AsyncClient(
             transport=get_transport(self.connection_config, http2=False),
         )
+
+    async def _raise_if_sandbox_killed(self, err: Exception) -> None:
+        """
+        Raises a descriptive exception if the connection error was caused by
+        the sandbox being killed mid-request. If the sandbox is still running
+        (or its state can't be determined), returns so the caller can re-raise
+        the original error.
+        """
+        try:
+            running = await self.is_running()
+        except Exception:
+            # The state check itself failed, so we can't tell whether the
+            # sandbox was killed — let the caller re-raise the original error
+            # instead of wrongly claiming the sandbox is gone.
+            return
+        if not running:
+            raise format_sandbox_killed_error() from err
 
     @overload
     async def run_code(
@@ -217,6 +235,9 @@ class AsyncSandbox(BaseAsyncSandbox):
             raise format_execution_timeout_error()
         except httpx.TimeoutException:
             raise format_request_timeout_error()
+        except (httpx.ReadError, httpx.RemoteProtocolError) as err:
+            await self._raise_if_sandbox_killed(err)
+            raise
 
     async def create_code_context(
         self,
@@ -263,6 +284,9 @@ class AsyncSandbox(BaseAsyncSandbox):
             return Context.from_json(data)
         except httpx.TimeoutException:
             raise format_request_timeout_error()
+        except (httpx.ReadError, httpx.RemoteProtocolError) as err:
+            await self._raise_if_sandbox_killed(err)
+            raise
 
     async def remove_code_context(
         self,
@@ -295,6 +319,9 @@ class AsyncSandbox(BaseAsyncSandbox):
                 raise err
         except httpx.TimeoutException:
             raise format_request_timeout_error()
+        except (httpx.ReadError, httpx.RemoteProtocolError) as err:
+            await self._raise_if_sandbox_killed(err)
+            raise
 
     async def list_code_contexts(self) -> List[Context]:
         """
@@ -323,6 +350,9 @@ class AsyncSandbox(BaseAsyncSandbox):
             return [Context.from_json(context_data) for context_data in data]
         except httpx.TimeoutException:
             raise format_request_timeout_error()
+        except (httpx.ReadError, httpx.RemoteProtocolError) as err:
+            await self._raise_if_sandbox_killed(err)
+            raise
 
     async def restart_code_context(
         self,
@@ -354,3 +384,6 @@ class AsyncSandbox(BaseAsyncSandbox):
                 raise err
         except httpx.TimeoutException:
             raise format_request_timeout_error()
+        except (httpx.ReadError, httpx.RemoteProtocolError) as err:
+            await self._raise_if_sandbox_killed(err)
+            raise

--- a/python/e2b_code_interpreter/code_interpreter_sync.py
+++ b/python/e2b_code_interpreter/code_interpreter_sync.py
@@ -25,6 +25,7 @@ from e2b_code_interpreter.models import (
 from e2b_code_interpreter.exceptions import (
     format_execution_timeout_error,
     format_request_timeout_error,
+    format_sandbox_killed_error,
 )
 
 logger = logging.getLogger(__name__)
@@ -76,6 +77,23 @@ class Sandbox(BaseSandbox):
         # server as a TCP close and long-running executions can be
         # cancelled reliably.
         return Client(transport=get_transport(self.connection_config, http2=False))
+
+    def _raise_if_sandbox_killed(self, err: Exception) -> None:
+        """
+        Raises a descriptive exception if the connection error was caused by
+        the sandbox being killed mid-request. If the sandbox is still running
+        (or its state can't be determined), returns so the caller can re-raise
+        the original error.
+        """
+        try:
+            running = self.is_running()
+        except Exception:
+            # The state check itself failed, so we can't tell whether the
+            # sandbox was killed — let the caller re-raise the original error
+            # instead of wrongly claiming the sandbox is gone.
+            return
+        if not running:
+            raise format_sandbox_killed_error() from err
 
     @overload
     def run_code(
@@ -210,6 +228,9 @@ class Sandbox(BaseSandbox):
             raise format_execution_timeout_error()
         except httpx.TimeoutException:
             raise format_request_timeout_error()
+        except (httpx.ReadError, httpx.RemoteProtocolError) as err:
+            self._raise_if_sandbox_killed(err)
+            raise
 
     def create_code_context(
         self,
@@ -256,6 +277,9 @@ class Sandbox(BaseSandbox):
             return Context.from_json(data)
         except httpx.TimeoutException:
             raise format_request_timeout_error()
+        except (httpx.ReadError, httpx.RemoteProtocolError) as err:
+            self._raise_if_sandbox_killed(err)
+            raise
 
     def remove_code_context(
         self,
@@ -288,6 +312,9 @@ class Sandbox(BaseSandbox):
                 raise err
         except httpx.TimeoutException:
             raise format_request_timeout_error()
+        except (httpx.ReadError, httpx.RemoteProtocolError) as err:
+            self._raise_if_sandbox_killed(err)
+            raise
 
     def list_code_contexts(self) -> List[Context]:
         """
@@ -316,6 +343,9 @@ class Sandbox(BaseSandbox):
             return [Context.from_json(context_data) for context_data in data]
         except httpx.TimeoutException:
             raise format_request_timeout_error()
+        except (httpx.ReadError, httpx.RemoteProtocolError) as err:
+            self._raise_if_sandbox_killed(err)
+            raise
 
     def restart_code_context(
         self,
@@ -348,3 +378,6 @@ class Sandbox(BaseSandbox):
                 raise err
         except httpx.TimeoutException:
             raise format_request_timeout_error()
+        except (httpx.ReadError, httpx.RemoteProtocolError) as err:
+            self._raise_if_sandbox_killed(err)
+            raise

--- a/python/e2b_code_interpreter/code_interpreter_sync.py
+++ b/python/e2b_code_interpreter/code_interpreter_sync.py
@@ -78,7 +78,7 @@ class Sandbox(BaseSandbox):
         # cancelled reliably.
         return Client(transport=get_transport(self.connection_config, http2=False))
 
-    def _raise_if_sandbox_killed(self, err: Exception) -> None:
+    def _handle_connection_error(self, err: Exception) -> None:
         """
         Raises a descriptive exception if the connection error was caused by
         the sandbox being killed mid-request. If the sandbox is still running
@@ -229,7 +229,7 @@ class Sandbox(BaseSandbox):
         except httpx.TimeoutException:
             raise format_request_timeout_error()
         except (httpx.ReadError, httpx.RemoteProtocolError) as err:
-            self._raise_if_sandbox_killed(err)
+            self._handle_connection_error(err)
             raise
 
     def create_code_context(
@@ -278,7 +278,7 @@ class Sandbox(BaseSandbox):
         except httpx.TimeoutException:
             raise format_request_timeout_error()
         except (httpx.ReadError, httpx.RemoteProtocolError) as err:
-            self._raise_if_sandbox_killed(err)
+            self._handle_connection_error(err)
             raise
 
     def remove_code_context(
@@ -313,7 +313,7 @@ class Sandbox(BaseSandbox):
         except httpx.TimeoutException:
             raise format_request_timeout_error()
         except (httpx.ReadError, httpx.RemoteProtocolError) as err:
-            self._raise_if_sandbox_killed(err)
+            self._handle_connection_error(err)
             raise
 
     def list_code_contexts(self) -> List[Context]:
@@ -344,7 +344,7 @@ class Sandbox(BaseSandbox):
         except httpx.TimeoutException:
             raise format_request_timeout_error()
         except (httpx.ReadError, httpx.RemoteProtocolError) as err:
-            self._raise_if_sandbox_killed(err)
+            self._handle_connection_error(err)
             raise
 
     def restart_code_context(
@@ -379,5 +379,5 @@ class Sandbox(BaseSandbox):
         except httpx.TimeoutException:
             raise format_request_timeout_error()
         except (httpx.ReadError, httpx.RemoteProtocolError) as err:
-            self._raise_if_sandbox_killed(err)
+            self._handle_connection_error(err)
             raise

--- a/python/e2b_code_interpreter/exceptions.py
+++ b/python/e2b_code_interpreter/exceptions.py
@@ -1,4 +1,4 @@
-from e2b import SandboxException, TimeoutException
+from e2b import TimeoutException
 
 
 def format_request_timeout_error() -> Exception:
@@ -14,7 +14,7 @@ def format_execution_timeout_error() -> Exception:
 
 
 def format_sandbox_killed_error() -> Exception:
-    return SandboxException(
+    return TimeoutException(
         "The sandbox was killed while the request was in progress. This can happen when the sandbox times out or is killed manually. "
         "You can modify the sandbox timeout by passing 'timeout' when starting the sandbox or calling '.set_timeout' on the sandbox with the desired timeout",
     )

--- a/python/e2b_code_interpreter/exceptions.py
+++ b/python/e2b_code_interpreter/exceptions.py
@@ -1,4 +1,4 @@
-from e2b import TimeoutException
+from e2b import SandboxException, TimeoutException
 
 
 def format_request_timeout_error() -> Exception:
@@ -10,4 +10,11 @@ def format_request_timeout_error() -> Exception:
 def format_execution_timeout_error() -> Exception:
     return TimeoutException(
         "Execution timed out — the 'timeout' option can be used to increase this timeout",
+    )
+
+
+def format_sandbox_killed_error() -> Exception:
+    return SandboxException(
+        "The sandbox was killed while the request was in progress. This can happen when the sandbox times out or is killed manually. "
+        "You can modify the sandbox timeout by passing 'timeout' when starting the sandbox or calling '.set_timeout' on the sandbox with the desired timeout",
     )

--- a/python/tests/async/test_async_killed.py
+++ b/python/tests/async/test_async_killed.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from e2b import SandboxException
+from e2b import TimeoutException
 from e2b_code_interpreter import AsyncSandbox
 
 
@@ -18,6 +18,6 @@ async def test_run_code_raises_when_sandbox_is_killed_during_execution(
     await async_sandbox.kill()
 
     with pytest.raises(
-        SandboxException, match="sandbox was killed while the request was in progress"
+        TimeoutException, match="sandbox was killed while the request was in progress"
     ):
         await execution

--- a/python/tests/async/test_async_killed.py
+++ b/python/tests/async/test_async_killed.py
@@ -1,0 +1,23 @@
+import asyncio
+
+import pytest
+
+from e2b import SandboxException
+from e2b_code_interpreter import AsyncSandbox
+
+
+@pytest.mark.skip_debug
+async def test_run_code_raises_when_sandbox_is_killed_during_execution(
+    async_sandbox: AsyncSandbox,
+):
+    execution = asyncio.create_task(
+        async_sandbox.run_code("import time; time.sleep(60)")
+    )
+
+    await asyncio.sleep(2)
+    await async_sandbox.kill()
+
+    with pytest.raises(
+        SandboxException, match="sandbox was killed while the request was in progress"
+    ):
+        await execution

--- a/python/tests/async/test_async_killed.py
+++ b/python/tests/async/test_async_killed.py
@@ -10,8 +10,12 @@ from e2b_code_interpreter import AsyncSandbox
 async def test_run_code_raises_when_sandbox_is_killed_during_execution(
     async_sandbox: AsyncSandbox,
 ):
+    # Keep the execution firmly in-flight until the kill: the sleep is far
+    # longer than the kill delay and the execution timeout is well beyond the
+    # kill + disconnect-detection window, so the only thing that ends the
+    # request is the sandbox being killed.
     execution = asyncio.create_task(
-        async_sandbox.run_code("import time; time.sleep(60)")
+        async_sandbox.run_code("import time; time.sleep(300)", timeout=300)
     )
 
     await asyncio.sleep(2)

--- a/python/tests/sync/test_killed.py
+++ b/python/tests/sync/test_killed.py
@@ -16,6 +16,10 @@ def test_run_code_raises_when_sandbox_is_killed_during_execution(sandbox: Sandbo
             TimeoutException,
             match="sandbox was killed while the request was in progress",
         ):
-            sandbox.run_code("import time; time.sleep(60)")
+            # Keep the execution firmly in-flight until the kill: the sleep is
+            # far longer than the kill delay and the execution timeout is well
+            # beyond the kill + disconnect-detection window, so the only thing
+            # that ends the request is the sandbox being killed.
+            sandbox.run_code("import time; time.sleep(300)", timeout=300)
     finally:
         timer.cancel()

--- a/python/tests/sync/test_killed.py
+++ b/python/tests/sync/test_killed.py
@@ -1,0 +1,21 @@
+import threading
+
+import pytest
+
+from e2b import SandboxException
+from e2b_code_interpreter import Sandbox
+
+
+@pytest.mark.skip_debug
+def test_run_code_raises_when_sandbox_is_killed_during_execution(sandbox: Sandbox):
+    timer = threading.Timer(2.0, sandbox.kill)
+    timer.start()
+
+    try:
+        with pytest.raises(
+            SandboxException,
+            match="sandbox was killed while the request was in progress",
+        ):
+            sandbox.run_code("import time; time.sleep(60)")
+    finally:
+        timer.cancel()

--- a/python/tests/sync/test_killed.py
+++ b/python/tests/sync/test_killed.py
@@ -2,7 +2,7 @@ import threading
 
 import pytest
 
-from e2b import SandboxException
+from e2b import TimeoutException
 from e2b_code_interpreter import Sandbox
 
 
@@ -13,7 +13,7 @@ def test_run_code_raises_when_sandbox_is_killed_during_execution(sandbox: Sandbo
 
     try:
         with pytest.raises(
-            SandboxException,
+            TimeoutException,
             match="sandbox was killed while the request was in progress",
         ):
             sandbox.run_code("import time; time.sleep(60)")


### PR DESCRIPTION
When the sandbox is killed or times out while a request is in flight, `runCode`/`run_code` and the context-management methods surfaced a raw socket error (e.g. `ECONNRESET` on Bun, `TypeError: fetch failed` on Node, `httpx.ReadError`/`RemoteProtocolError` in Python). Both SDKs now detect the closed connection across runtimes, confirm via the sandbox health check that it's actually gone, and throw a descriptive `SandboxError`/`SandboxException` suggesting `timeoutMs`/`.setTimeout` instead. If the sandbox is still running or its state can't be determined, the original error propagates unchanged so genuine network issues aren't masked. Includes kill-during-execution tests for JS, Python sync, and Python async (verified against the live API on Node and Bun), plus a patch changeset for both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)