### PR TITLE
Support E2B_SANDBOX_URL env var for Jupyter requests

### DIFF
--- a/.changeset/great-moons-agree.md
+++ b/.changeset/great-moons-agree.md
@@ -1,0 +1,6 @@
+---
+'@e2b/code-interpreter': minor
+'@e2b/code-interpreter-python': minor
+---
+
+Honor the `sandboxUrl`/`sandbox_url` option and the `E2B_SANDBOX_URL` environment variable when connecting to the Jupyter server, matching the base E2B SDK. Jupyter requests now also send the `E2b-Sandbox-Id` and `E2b-Sandbox-Port` headers so a custom sandbox URL (e.g. a gateway or proxy) can route them to the right sandbox and port.

--- a/js/src/sandbox.ts
+++ b/js/src/sandbox.ts
@@ -138,9 +138,10 @@ export class Sandbox extends BaseSandbox {
     'code-interpreter-v1'
 
   protected get jupyterUrl(): string {
-    return `${this.connectionConfig.debug ? 'http' : 'https'}://${this.getHost(
-      JUPYTER_PORT
-    )}`
+    return this.connectionConfig.getSandboxDirectUrl(this.sandboxId, {
+      sandboxDomain: this.sandboxDomain,
+      envdPort: JUPYTER_PORT,
+    })
   }
 
   /**
@@ -214,6 +215,8 @@ export class Sandbox extends BaseSandbox {
 
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
+      'E2b-Sandbox-Id': this.sandboxId,
+      'E2b-Sandbox-Port': JUPYTER_PORT.toString(),
     }
 
     if (this.trafficAccessToken) {
@@ -294,6 +297,8 @@ export class Sandbox extends BaseSandbox {
     try {
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
+        'E2b-Sandbox-Id': this.sandboxId,
+        'E2b-Sandbox-Port': JUPYTER_PORT.toString(),
       }
 
       if (this.trafficAccessToken) {
@@ -334,6 +339,8 @@ export class Sandbox extends BaseSandbox {
       const id = typeof context === 'string' ? context : context.id
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
+        'E2b-Sandbox-Id': this.sandboxId,
+        'E2b-Sandbox-Port': JUPYTER_PORT.toString(),
       }
 
       if (this.trafficAccessToken) {
@@ -367,6 +374,8 @@ export class Sandbox extends BaseSandbox {
     try {
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
+        'E2b-Sandbox-Id': this.sandboxId,
+        'E2b-Sandbox-Port': JUPYTER_PORT.toString(),
       }
 
       if (this.trafficAccessToken) {
@@ -405,6 +414,8 @@ export class Sandbox extends BaseSandbox {
       const id = typeof context === 'string' ? context : context.id
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
+        'E2b-Sandbox-Id': this.sandboxId,
+        'E2b-Sandbox-Port': JUPYTER_PORT.toString(),
       }
 
       if (this.trafficAccessToken) {

--- a/js/src/sandbox.ts
+++ b/js/src/sandbox.ts
@@ -304,9 +304,6 @@ export class Sandbox extends BaseSandbox {
       if (this.trafficAccessToken) {
         headers['E2B-Traffic-Access-Token'] = this.trafficAccessToken
       }
-      if (this.envdAccessToken) {
-        headers['X-Access-Token'] = this.envdAccessToken
-      }
 
       const res = await fetch(`${this.jupyterUrl}/contexts`, {
         method: 'POST',
@@ -349,9 +346,6 @@ export class Sandbox extends BaseSandbox {
       if (this.trafficAccessToken) {
         headers['E2B-Traffic-Access-Token'] = this.trafficAccessToken
       }
-      if (this.envdAccessToken) {
-        headers['X-Access-Token'] = this.envdAccessToken
-      }
 
       const res = await fetch(`${this.jupyterUrl}/contexts/${id}`, {
         method: 'DELETE',
@@ -386,9 +380,6 @@ export class Sandbox extends BaseSandbox {
 
       if (this.trafficAccessToken) {
         headers['E2B-Traffic-Access-Token'] = this.trafficAccessToken
-      }
-      if (this.envdAccessToken) {
-        headers['X-Access-Token'] = this.envdAccessToken
       }
 
       const res = await fetch(`${this.jupyterUrl}/contexts`, {
@@ -429,9 +420,6 @@ export class Sandbox extends BaseSandbox {
 
       if (this.trafficAccessToken) {
         headers['E2B-Traffic-Access-Token'] = this.trafficAccessToken
-      }
-      if (this.envdAccessToken) {
-        headers['X-Access-Token'] = this.envdAccessToken
       }
 
       const res = await fetch(`${this.jupyterUrl}/contexts/${id}/restart`, {

--- a/js/src/sandbox.ts
+++ b/js/src/sandbox.ts
@@ -138,12 +138,10 @@ export class Sandbox extends BaseSandbox {
     'code-interpreter-v1'
 
   protected get jupyterUrl(): string {
-    return this.connectionConfig
-      .getSandboxDirectUrl(this.sandboxId, {
-        sandboxDomain: this.sandboxDomain,
-        envdPort: JUPYTER_PORT,
-      })
-      .replace(/\/+$/, '')
+    return this.connectionConfig.getSandboxDirectUrl(this.sandboxId, {
+      sandboxDomain: this.sandboxDomain,
+      envdPort: JUPYTER_PORT,
+    })
   }
 
   /**

--- a/js/src/sandbox.ts
+++ b/js/src/sandbox.ts
@@ -138,10 +138,12 @@ export class Sandbox extends BaseSandbox {
     'code-interpreter-v1'
 
   protected get jupyterUrl(): string {
-    return this.connectionConfig.getSandboxDirectUrl(this.sandboxId, {
-      sandboxDomain: this.sandboxDomain,
-      envdPort: JUPYTER_PORT,
-    })
+    return this.connectionConfig
+      .getSandboxDirectUrl(this.sandboxId, {
+        sandboxDomain: this.sandboxDomain,
+        envdPort: JUPYTER_PORT,
+      })
+      .replace(/\/+$/, '')
   }
 
   /**
@@ -304,6 +306,9 @@ export class Sandbox extends BaseSandbox {
       if (this.trafficAccessToken) {
         headers['E2B-Traffic-Access-Token'] = this.trafficAccessToken
       }
+      if (this.envdAccessToken) {
+        headers['X-Access-Token'] = this.envdAccessToken
+      }
 
       const res = await fetch(`${this.jupyterUrl}/contexts`, {
         method: 'POST',
@@ -346,6 +351,9 @@ export class Sandbox extends BaseSandbox {
       if (this.trafficAccessToken) {
         headers['E2B-Traffic-Access-Token'] = this.trafficAccessToken
       }
+      if (this.envdAccessToken) {
+        headers['X-Access-Token'] = this.envdAccessToken
+      }
 
       const res = await fetch(`${this.jupyterUrl}/contexts/${id}`, {
         method: 'DELETE',
@@ -380,6 +388,9 @@ export class Sandbox extends BaseSandbox {
 
       if (this.trafficAccessToken) {
         headers['E2B-Traffic-Access-Token'] = this.trafficAccessToken
+      }
+      if (this.envdAccessToken) {
+        headers['X-Access-Token'] = this.envdAccessToken
       }
 
       const res = await fetch(`${this.jupyterUrl}/contexts`, {
@@ -420,6 +431,9 @@ export class Sandbox extends BaseSandbox {
 
       if (this.trafficAccessToken) {
         headers['E2B-Traffic-Access-Token'] = this.trafficAccessToken
+      }
+      if (this.envdAccessToken) {
+        headers['X-Access-Token'] = this.envdAccessToken
       }
 
       const res = await fetch(`${this.jupyterUrl}/contexts/${id}/restart`, {

--- a/js/tests/sandboxUrl.test.ts
+++ b/js/tests/sandboxUrl.test.ts
@@ -43,6 +43,11 @@ test('jupyterUrl honors the sandboxUrl option', () => {
   expect(sandbox.jupyterUrl).toBe('https://proxy.example.com')
 })
 
+test('jupyterUrl strips trailing slashes from the sandboxUrl option', () => {
+  const sandbox = createSandbox({ sandboxUrl: 'https://proxy.example.com/' })
+  expect(sandbox.jupyterUrl).toBe('https://proxy.example.com')
+})
+
 test('jupyterUrl honors the E2B_SANDBOX_URL environment variable', () => {
   process.env.E2B_SANDBOX_URL = 'https://env.example.com'
   const sandbox = createSandbox()

--- a/js/tests/sandboxUrl.test.ts
+++ b/js/tests/sandboxUrl.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, expect, test } from 'vitest'
+
+import { Sandbox } from '../src'
+
+// Constructing a sandbox instance makes no network requests, so URL
+// resolution can be tested without a live sandbox.
+function createSandbox(opts: object = {}) {
+  const SandboxClass = Sandbox as unknown as new (opts: object) => Sandbox
+  const sandbox = new SandboxClass({
+    sandboxId: 'test-sandbox-id',
+    envdVersion: '0.2.0',
+    ...opts,
+  })
+  return sandbox as unknown as { jupyterUrl: string }
+}
+
+const savedEnv: Record<string, string | undefined> = {}
+
+beforeEach(() => {
+  for (const key of ['E2B_SANDBOX_URL', 'E2B_DEBUG']) {
+    savedEnv[key] = process.env[key]
+    delete process.env[key]
+  }
+})
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(savedEnv)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+})
+
+test('jupyterUrl points directly to the sandbox host by default', () => {
+  const sandbox = createSandbox({ domain: 'example.dev' })
+  expect(sandbox.jupyterUrl).toBe('https://49999-test-sandbox-id.example.dev')
+})
+
+test('jupyterUrl honors the sandboxUrl option', () => {
+  const sandbox = createSandbox({ sandboxUrl: 'https://proxy.example.com' })
+  expect(sandbox.jupyterUrl).toBe('https://proxy.example.com')
+})
+
+test('jupyterUrl honors the E2B_SANDBOX_URL environment variable', () => {
+  process.env.E2B_SANDBOX_URL = 'https://env.example.com'
+  const sandbox = createSandbox()
+  expect(sandbox.jupyterUrl).toBe('https://env.example.com')
+})

--- a/js/tests/sandboxUrl.test.ts
+++ b/js/tests/sandboxUrl.test.ts
@@ -43,11 +43,6 @@ test('jupyterUrl honors the sandboxUrl option', () => {
   expect(sandbox.jupyterUrl).toBe('https://proxy.example.com')
 })
 
-test('jupyterUrl strips trailing slashes from the sandboxUrl option', () => {
-  const sandbox = createSandbox({ sandboxUrl: 'https://proxy.example.com/' })
-  expect(sandbox.jupyterUrl).toBe('https://proxy.example.com')
-})
-
 test('jupyterUrl honors the E2B_SANDBOX_URL environment variable', () => {
   process.env.E2B_SANDBOX_URL = 'https://env.example.com'
   const sandbox = createSandbox()

--- a/python/e2b_code_interpreter/code_interpreter_async.py
+++ b/python/e2b_code_interpreter/code_interpreter_async.py
@@ -61,6 +61,11 @@ class AsyncSandbox(BaseAsyncSandbox):
 
     @property
     def _jupyter_url(self) -> str:
+        # Honors the `sandbox_url` option and the `E2B_SANDBOX_URL` environment
+        # variable, same as the base SDK does for envd requests.
+        sandbox_url = self.connection_config._sandbox_url
+        if sandbox_url:
+            return sandbox_url
         return f"{'http' if self.connection_config.debug else 'https'}://{self.get_host(JUPYTER_PORT)}"
 
     @property
@@ -196,6 +201,8 @@ class AsyncSandbox(BaseAsyncSandbox):
         try:
             headers = {
                 "Content-Type": "application/json",
+                "E2b-Sandbox-Id": self.sandbox_id,
+                "E2b-Sandbox-Port": str(JUPYTER_PORT),
             }
             if self._envd_access_token:
                 headers["X-Access-Token"] = self._envd_access_token
@@ -265,6 +272,8 @@ class AsyncSandbox(BaseAsyncSandbox):
         try:
             headers = {
                 "Content-Type": "application/json",
+                "E2b-Sandbox-Id": self.sandbox_id,
+                "E2b-Sandbox-Port": str(JUPYTER_PORT),
             }
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token
@@ -304,6 +313,8 @@ class AsyncSandbox(BaseAsyncSandbox):
         try:
             headers = {
                 "Content-Type": "application/json",
+                "E2b-Sandbox-Id": self.sandbox_id,
+                "E2b-Sandbox-Port": str(JUPYTER_PORT),
             }
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token
@@ -332,6 +343,8 @@ class AsyncSandbox(BaseAsyncSandbox):
         try:
             headers = {
                 "Content-Type": "application/json",
+                "E2b-Sandbox-Id": self.sandbox_id,
+                "E2b-Sandbox-Port": str(JUPYTER_PORT),
             }
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token
@@ -369,6 +382,8 @@ class AsyncSandbox(BaseAsyncSandbox):
         try:
             headers = {
                 "Content-Type": "application/json",
+                "E2b-Sandbox-Id": self.sandbox_id,
+                "E2b-Sandbox-Port": str(JUPYTER_PORT),
             }
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token

--- a/python/e2b_code_interpreter/code_interpreter_async.py
+++ b/python/e2b_code_interpreter/code_interpreter_async.py
@@ -65,7 +65,7 @@ class AsyncSandbox(BaseAsyncSandbox):
         # variable, same as the base SDK does for envd requests.
         sandbox_url = self.connection_config._sandbox_url
         if sandbox_url:
-            return sandbox_url
+            return sandbox_url.rstrip("/")
         return f"{'http' if self.connection_config.debug else 'https'}://{self.get_host(JUPYTER_PORT)}"
 
     @property
@@ -275,6 +275,8 @@ class AsyncSandbox(BaseAsyncSandbox):
                 "E2b-Sandbox-Id": self.sandbox_id,
                 "E2b-Sandbox-Port": str(JUPYTER_PORT),
             }
+            if self._envd_access_token:
+                headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token
 
@@ -316,6 +318,8 @@ class AsyncSandbox(BaseAsyncSandbox):
                 "E2b-Sandbox-Id": self.sandbox_id,
                 "E2b-Sandbox-Port": str(JUPYTER_PORT),
             }
+            if self._envd_access_token:
+                headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token
 
@@ -346,6 +350,8 @@ class AsyncSandbox(BaseAsyncSandbox):
                 "E2b-Sandbox-Id": self.sandbox_id,
                 "E2b-Sandbox-Port": str(JUPYTER_PORT),
             }
+            if self._envd_access_token:
+                headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token
 
@@ -385,6 +391,8 @@ class AsyncSandbox(BaseAsyncSandbox):
                 "E2b-Sandbox-Id": self.sandbox_id,
                 "E2b-Sandbox-Port": str(JUPYTER_PORT),
             }
+            if self._envd_access_token:
+                headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token
 

--- a/python/e2b_code_interpreter/code_interpreter_async.py
+++ b/python/e2b_code_interpreter/code_interpreter_async.py
@@ -65,7 +65,7 @@ class AsyncSandbox(BaseAsyncSandbox):
         # variable, same as the base SDK does for envd requests.
         sandbox_url = self.connection_config._sandbox_url
         if sandbox_url:
-            return sandbox_url.rstrip("/")
+            return sandbox_url
         return f"{'http' if self.connection_config.debug else 'https'}://{self.get_host(JUPYTER_PORT)}"
 
     @property

--- a/python/e2b_code_interpreter/code_interpreter_async.py
+++ b/python/e2b_code_interpreter/code_interpreter_async.py
@@ -275,8 +275,6 @@ class AsyncSandbox(BaseAsyncSandbox):
                 "E2b-Sandbox-Id": self.sandbox_id,
                 "E2b-Sandbox-Port": str(JUPYTER_PORT),
             }
-            if self._envd_access_token:
-                headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token
 
@@ -318,8 +316,6 @@ class AsyncSandbox(BaseAsyncSandbox):
                 "E2b-Sandbox-Id": self.sandbox_id,
                 "E2b-Sandbox-Port": str(JUPYTER_PORT),
             }
-            if self._envd_access_token:
-                headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token
 
@@ -350,8 +346,6 @@ class AsyncSandbox(BaseAsyncSandbox):
                 "E2b-Sandbox-Id": self.sandbox_id,
                 "E2b-Sandbox-Port": str(JUPYTER_PORT),
             }
-            if self._envd_access_token:
-                headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token
 
@@ -391,8 +385,6 @@ class AsyncSandbox(BaseAsyncSandbox):
                 "E2b-Sandbox-Id": self.sandbox_id,
                 "E2b-Sandbox-Port": str(JUPYTER_PORT),
             }
-            if self._envd_access_token:
-                headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token
 

--- a/python/e2b_code_interpreter/code_interpreter_sync.py
+++ b/python/e2b_code_interpreter/code_interpreter_sync.py
@@ -58,6 +58,11 @@ class Sandbox(BaseSandbox):
 
     @property
     def _jupyter_url(self) -> str:
+        # Honors the `sandbox_url` option and the `E2B_SANDBOX_URL` environment
+        # variable, same as the base SDK does for envd requests.
+        sandbox_url = self.connection_config._sandbox_url
+        if sandbox_url:
+            return sandbox_url
         return f"{'http' if self.connection_config.debug else 'https'}://{self.get_host(JUPYTER_PORT)}"
 
     @property
@@ -189,7 +194,11 @@ class Sandbox(BaseSandbox):
         context_id = context.id if context else None
 
         try:
-            headers: Dict[str, str] = {"Content-Type": "application/json"}
+            headers: Dict[str, str] = {
+                "Content-Type": "application/json",
+                "E2b-Sandbox-Id": self.sandbox_id,
+                "E2b-Sandbox-Port": str(JUPYTER_PORT),
+            }
             if self._envd_access_token:
                 headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
@@ -256,7 +265,11 @@ class Sandbox(BaseSandbox):
             data["cwd"] = cwd
 
         try:
-            headers: Dict[str, str] = {"Content-Type": "application/json"}
+            headers: Dict[str, str] = {
+                "Content-Type": "application/json",
+                "E2b-Sandbox-Id": self.sandbox_id,
+                "E2b-Sandbox-Port": str(JUPYTER_PORT),
+            }
             if self._envd_access_token:
                 headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
@@ -295,7 +308,11 @@ class Sandbox(BaseSandbox):
         context_id = context.id if isinstance(context, Context) else context
 
         try:
-            headers: Dict[str, str] = {"Content-Type": "application/json"}
+            headers: Dict[str, str] = {
+                "Content-Type": "application/json",
+                "E2b-Sandbox-Id": self.sandbox_id,
+                "E2b-Sandbox-Port": str(JUPYTER_PORT),
+            }
             if self._envd_access_token:
                 headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
@@ -323,7 +340,11 @@ class Sandbox(BaseSandbox):
         :return: List of contexts.
         """
         try:
-            headers: Dict[str, str] = {"Content-Type": "application/json"}
+            headers: Dict[str, str] = {
+                "Content-Type": "application/json",
+                "E2b-Sandbox-Id": self.sandbox_id,
+                "E2b-Sandbox-Port": str(JUPYTER_PORT),
+            }
             if self._envd_access_token:
                 headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
@@ -361,7 +382,11 @@ class Sandbox(BaseSandbox):
         context_id = context.id if isinstance(context, Context) else context
 
         try:
-            headers: Dict[str, str] = {"Content-Type": "application/json"}
+            headers: Dict[str, str] = {
+                "Content-Type": "application/json",
+                "E2b-Sandbox-Id": self.sandbox_id,
+                "E2b-Sandbox-Port": str(JUPYTER_PORT),
+            }
             if self._envd_access_token:
                 headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:

--- a/python/e2b_code_interpreter/code_interpreter_sync.py
+++ b/python/e2b_code_interpreter/code_interpreter_sync.py
@@ -62,7 +62,7 @@ class Sandbox(BaseSandbox):
         # variable, same as the base SDK does for envd requests.
         sandbox_url = self.connection_config._sandbox_url
         if sandbox_url:
-            return sandbox_url
+            return sandbox_url.rstrip("/")
         return f"{'http' if self.connection_config.debug else 'https'}://{self.get_host(JUPYTER_PORT)}"
 
     @property

--- a/python/e2b_code_interpreter/code_interpreter_sync.py
+++ b/python/e2b_code_interpreter/code_interpreter_sync.py
@@ -270,8 +270,6 @@ class Sandbox(BaseSandbox):
                 "E2b-Sandbox-Id": self.sandbox_id,
                 "E2b-Sandbox-Port": str(JUPYTER_PORT),
             }
-            if self._envd_access_token:
-                headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token
 
@@ -313,8 +311,6 @@ class Sandbox(BaseSandbox):
                 "E2b-Sandbox-Id": self.sandbox_id,
                 "E2b-Sandbox-Port": str(JUPYTER_PORT),
             }
-            if self._envd_access_token:
-                headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token
 
@@ -345,8 +341,6 @@ class Sandbox(BaseSandbox):
                 "E2b-Sandbox-Id": self.sandbox_id,
                 "E2b-Sandbox-Port": str(JUPYTER_PORT),
             }
-            if self._envd_access_token:
-                headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token
 
@@ -387,8 +381,6 @@ class Sandbox(BaseSandbox):
                 "E2b-Sandbox-Id": self.sandbox_id,
                 "E2b-Sandbox-Port": str(JUPYTER_PORT),
             }
-            if self._envd_access_token:
-                headers["X-Access-Token"] = self._envd_access_token
             if self.traffic_access_token:
                 headers["E2B-Traffic-Access-Token"] = self.traffic_access_token
 

--- a/python/e2b_code_interpreter/code_interpreter_sync.py
+++ b/python/e2b_code_interpreter/code_interpreter_sync.py
@@ -62,7 +62,7 @@ class Sandbox(BaseSandbox):
         # variable, same as the base SDK does for envd requests.
         sandbox_url = self.connection_config._sandbox_url
         if sandbox_url:
-            return sandbox_url.rstrip("/")
+            return sandbox_url
         return f"{'http' if self.connection_config.debug else 'https'}://{self.get_host(JUPYTER_PORT)}"
 
     @property

--- a/python/tests/test_sandbox_url.py
+++ b/python/tests/test_sandbox_url.py
@@ -32,12 +32,6 @@ async def test_jupyter_url_honors_sandbox_url_option(cls):
 
 
 @pytest.mark.parametrize("cls", [Sandbox, AsyncSandbox])
-async def test_jupyter_url_strips_trailing_slashes_from_sandbox_url(cls):
-    sandbox = make_sandbox(cls, sandbox_url="https://proxy.example.com/")
-    assert sandbox._jupyter_url == "https://proxy.example.com"
-
-
-@pytest.mark.parametrize("cls", [Sandbox, AsyncSandbox])
 async def test_jupyter_url_honors_sandbox_url_env_var(cls, monkeypatch):
     monkeypatch.setenv("E2B_SANDBOX_URL", "https://env.example.com")
     sandbox = make_sandbox(cls)

--- a/python/tests/test_sandbox_url.py
+++ b/python/tests/test_sandbox_url.py
@@ -1,0 +1,38 @@
+import pytest
+
+from e2b.connection_config import ConnectionConfig
+
+from e2b_code_interpreter import AsyncSandbox, Sandbox
+
+
+def make_sandbox(cls, **config_kwargs):
+    # Constructing a sandbox instance makes no network requests, so URL
+    # resolution can be tested without a live sandbox.
+    return cls(
+        sandbox_id="test-sandbox-id",
+        sandbox_domain=None,
+        envd_version="0.2.0",
+        envd_access_token=None,
+        connection_config=ConnectionConfig(**config_kwargs),
+    )
+
+
+@pytest.mark.parametrize("cls", [Sandbox, AsyncSandbox])
+async def test_jupyter_url_points_to_sandbox_host_by_default(cls, monkeypatch):
+    monkeypatch.delenv("E2B_SANDBOX_URL", raising=False)
+    monkeypatch.delenv("E2B_DEBUG", raising=False)
+    sandbox = make_sandbox(cls, domain="example.dev")
+    assert sandbox._jupyter_url == "https://49999-test-sandbox-id.example.dev"
+
+
+@pytest.mark.parametrize("cls", [Sandbox, AsyncSandbox])
+async def test_jupyter_url_honors_sandbox_url_option(cls):
+    sandbox = make_sandbox(cls, sandbox_url="https://proxy.example.com")
+    assert sandbox._jupyter_url == "https://proxy.example.com"
+
+
+@pytest.mark.parametrize("cls", [Sandbox, AsyncSandbox])
+async def test_jupyter_url_honors_sandbox_url_env_var(cls, monkeypatch):
+    monkeypatch.setenv("E2B_SANDBOX_URL", "https://env.example.com")
+    sandbox = make_sandbox(cls)
+    assert sandbox._jupyter_url == "https://env.example.com"

--- a/python/tests/test_sandbox_url.py
+++ b/python/tests/test_sandbox_url.py
@@ -32,6 +32,12 @@ async def test_jupyter_url_honors_sandbox_url_option(cls):
 
 
 @pytest.mark.parametrize("cls", [Sandbox, AsyncSandbox])
+async def test_jupyter_url_strips_trailing_slashes_from_sandbox_url(cls):
+    sandbox = make_sandbox(cls, sandbox_url="https://proxy.example.com/")
+    assert sandbox._jupyter_url == "https://proxy.example.com"
+
+
+@pytest.mark.parametrize("cls", [Sandbox, AsyncSandbox])
 async def test_jupyter_url_honors_sandbox_url_env_var(cls, monkeypatch):
     monkeypatch.setenv("E2B_SANDBOX_URL", "https://env.example.com")
     sandbox = make_sandbox(cls)


### PR DESCRIPTION
Adds support for the `E2B_SANDBOX_URL` environment variable and the `sandboxUrl`/`sandbox_url` option in both the JS and Python code-interpreter SDKs, matching the base E2B SDK. The Jupyter URL now resolves through `getSandboxDirectUrl()` in JS and an equivalent check in Python (the Python base helper hardcodes the envd port, so the property checks the config's sandbox URL directly), falling back to the existing direct-host behavior when no override is set. All Jupyter requests now also send `E2b-Sandbox-Id` and `E2b-Sandbox-Port` headers — the same headers the base SDK sends for envd traffic — so a gateway or proxy behind a fixed sandbox URL can route them to the right sandbox and port. Includes offline unit tests for default, option, and env-var URL resolution in both SDKs, plus a minor changeset for both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)