### PR TITLE
Update dependency nltk to v3.10.0 [SECURITY]

### DIFF
--- a/.changeset/nltk-3-10-security.md
+++ b/.changeset/nltk-3-10-security.md
@@ -1,0 +1,5 @@
+---
+"@e2b/code-interpreter-template": patch
+---
+
+Bump `nltk` to 3.10.0 to address a security vulnerability (CVE-2026-54293)

--- a/template/requirements.txt
+++ b/template/requirements.txt
@@ -19,7 +19,7 @@ gensim==4.4.0
 imageio==2.37.3
 joblib==1.5.3
 librosa==0.11.0
-nltk==3.9.4
+nltk==3.10.0
 numpy==2.3.5
 numba==0.66.0
 opencv-python==4.11.0.86


### PR DESCRIPTION
Fixes [Dependabot alert #196](https://github.com/e2b-dev/code-interpreter/security/dependabot/196) — GHSA-p4gq-832x-fm9v / CVE-2026-54293 (high, CVSS 7.5).

`nltk.data.load()` in nltk ≤ 3.9.4 is vulnerable to URL-encoded path traversal (decode-after-check in `nltk/data.py`), allowing arbitrary local file read. Bumps the template's pin from 3.9.4 to the first patched version, 3.10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)