### PR TITLE
fix(ci): use E2B_API_KEY instead of deprecated E2B_ACCESS_TOKEN

### DIFF
--- a/.github/workflows/cleanup_build_template.yml
+++ b/.github/workflows/cleanup_build_template.yml
@@ -3,7 +3,7 @@ name: Cleanup Build Template
 on:
   workflow_call:
     secrets:
-      E2B_TESTS_ACCESS_TOKEN:
+      E2B_API_KEY:
         required: true
     inputs:
       E2B_DOMAIN:
@@ -29,5 +29,5 @@ jobs:
         run: |
           e2b template delete -y "${{ inputs.E2B_TESTS_TEMPLATE }}"
         env:
-          E2B_ACCESS_TOKEN: ${{ secrets.E2B_TESTS_ACCESS_TOKEN }}
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           E2B_DOMAIN: ${{ inputs.E2B_DOMAIN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -49,7 +49,7 @@ jobs:
     needs: [build-template, js-sdk, python-sdk, performance-tests]
     if: always() && !contains(needs.build-template.result, 'failure') && !contains(needs.build-template.result, 'cancelled')
     secrets:
-      E2B_TESTS_ACCESS_TOKEN: ${{ secrets.E2B_TESTS_ACCESS_TOKEN }}
+      E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
     with:
       E2B_DOMAIN: ${{ vars.E2B_DOMAIN }}
       E2B_TESTS_TEMPLATE: ${{ needs.build-template.outputs.template_id }}


### PR DESCRIPTION
The `cleanup-build-template` job was the last place in CI still authenticating with an access token, and it started failing with `[401] unauthorized: Invalid Access token` — `E2B_ACCESS_TOKEN is deprecated and no longer accepted`.

This switches `cleanup_build_template.yml` to take an `E2B_API_KEY` secret instead of `E2B_TESTS_ACCESS_TOKEN`, and updates `pull_request.yml` to pass `secrets.E2B_API_KEY` through — the same key that builds the template, so it has the right team scope. Verified against `@e2b/cli@2.16.1` that `template delete` authenticates via `X-API-KEY` from `E2B_API_KEY`, so no access token is needed.

`E2B_ACCESS_TOKEN` is now gone from the repo entirely; the `E2B_TESTS_ACCESS_TOKEN` repo secret is unreferenced and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)