### PR TITLE
chore: upgrade to pnpm 10, add 3-day minimum dependency age

### DIFF
--- a/.github/workflows/js_tests.yml
+++ b/.github/workflows/js_tests.yml
@@ -27,16 +27,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Parse .tool-versions
+        uses: wistia/parse-tool-versions@v2.1.1
+        with:
+          filename: '.tool-versions'
+          uppercase: 'true'
+          prefix: 'tool_version_'
+
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         id: pnpm-install
         with:
-          version: 9.5
+          version: ${{ env.TOOL_VERSION_PNPM }}
 
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: "20.x"
+          node-version: '${{ env.TOOL_VERSION_NODE }}'
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
@@ -62,7 +69,7 @@ jobs:
       - name: Install Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.14
+          bun-version: ${{ env.TOOL_VERSION_BUN }}
 
       - name: Run Bun tests
         run: pnpm test:bun

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,12 +24,12 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9.15.9
+          version: ${{ env.TOOL_VERSION_PNPM }}
 
       - name: Setup Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '${{ env.TOOL_VERSION_NODE }}'
           cache: pnpm
 
       - name: Configure pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,16 +21,23 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
+      - name: Parse .tool-versions
+        uses: wistia/parse-tool-versions@v2.1.1
+        with:
+          filename: '.tool-versions'
+          uppercase: 'true'
+          prefix: 'tool_version_'
+
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         id: pnpm-install
         with:
-          version: 9.5
+          version: ${{ env.TOOL_VERSION_PNPM }}
 
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: '${{ env.TOOL_VERSION_NODE }}'
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
@@ -63,16 +70,23 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
+      - name: Parse .tool-versions
+        uses: wistia/parse-tool-versions@v2.1.1
+        with:
+          filename: '.tool-versions'
+          uppercase: 'true'
+          prefix: 'tool_version_'
+
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         id: pnpm-install
         with:
-          version: 9.5
+          version: ${{ env.TOOL_VERSION_PNPM }}
 
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: '${{ env.TOOL_VERSION_NODE }}'
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
@@ -128,10 +142,10 @@ jobs:
           prefix: 'tool_version_'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         id: pnpm-install
         with:
-          version: 9.5
+          version: ${{ env.TOOL_VERSION_PNPM }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -327,9 +341,9 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
 
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
         with:
-          version: 9.5
+          version: ${{ env.TOOL_VERSION_PNPM }}
 
       - name: Setup Node.js 24
         uses: actions/setup-node@v6

--- a/.github/workflows/release_candidates.yml
+++ b/.github/workflows/release_candidates.yml
@@ -24,16 +24,16 @@ jobs:
           uppercase: 'true'
           prefix: 'tool_version_'
 
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
         if: ${{ contains( github.event.pull_request.labels.*.name, 'js-rc') }}
         with:
-          version: 9.5
+          version: ${{ env.TOOL_VERSION_PNPM }}
 
       - name: Setup Node.js 20
         uses: actions/setup-node@v4
         if: ${{ contains( github.event.pull_request.labels.*.name, 'js-rc') }}
         with:
-          node-version: "20.x"
+          node-version: '${{ env.TOOL_VERSION_NODE }}'
           registry-url: https://registry.npmjs.org
           cache: pnpm
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,11 @@
 python 3.10
 poetry 2.1.1
+# Keep in sync with `packageManager` in package.json, js/package.json and
+# python/package.json — pnpm self-switches to that version at runtime.
+pnpm 10.34.5
+# Baseline Node for build/test/lint. Matches the `engines.node` floor in
+# js/package.json, so CI exercises the oldest version the SDK claims to support.
+# The release job in release.yml deliberately overrides this with Node 24 to get
+# npm 11 for OIDC trusted publishing (see #259).
+node 20
+bun 1.3.14

--- a/js/package.json
+++ b/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@e2b/code-interpreter",
   "version": "2.7.0",
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.34.5",
   "description": "E2B Code Interpreter - Stateful code execution",
   "homepage": "https://e2b.dev",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "format": "pnpm --if-present --recursive run format",
     "changeset": "pnpx @changesets/cli"
   },
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.34.5",
   "devDependencies": {
     "@changesets/read": "^0.6.2",
     "changeset": "^0.2.6",
@@ -21,7 +21,7 @@
     "prettier": "^3.6.2"
   },
   "engines": {
-    "pnpm": ">=9.0.0 <10"
+    "pnpm": ">=10.16.0 <11"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,15 @@ packages:
   - python
   - chart_data_extractor
   - template
+
+# Only install package versions that have been on the registry for at least
+# 3 days, so malicious releases have time to be caught and unpublished.
+minimumReleaseAge: 4320
+
+# `e2b` is our own SDK — we control its releases, so it doesn't need the delay.
+minimumReleaseAgeExclude:
+  - e2b
+
+# pnpm 10 blocks dependency lifecycle scripts unless listed here.
+onlyBuiltDependencies:
+  - esbuild

--- a/python/package.json
+++ b/python/package.json
@@ -2,7 +2,7 @@
   "name": "@e2b/code-interpreter-python",
   "private": true,
   "version": "2.9.0",
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@10.34.5",
   "scripts": {
     "test": "poetry run pytest -n 4 --verbose -x",
     "example": "poetry run python3 example.py",

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,10 +9,19 @@
   //    "0 * * * *"
   //  ],
   timezone: 'UTC',
+  // Keep in sync with `minimumReleaseAge` in pnpm-workspace.yaml (4320 minutes),
+  // otherwise Renovate proposes versions pnpm then refuses to install.
+  minimumReleaseAge: '3 days',
   // Always squash PRs when automerging
   automergeType: 'pr',
   automergeStrategy: 'squash',
   packageRules: [
+    {
+      // Keep in sync with `minimumReleaseAgeExclude` in pnpm-workspace.yaml.
+      description: 'e2b is our own SDK, so it skips the minimum release age',
+      matchPackageNames: ['e2b'],
+      minimumReleaseAge: null,
+    },
     {
       description: 'Group and automerge patch updates after CI passes',
       matchUpdateTypes: ['patch'],


### PR DESCRIPTION
Bumps pnpm 9.15.9 → 10.34.5 across `packageManager` fields, `engines`, and all seven `pnpm/action-setup` steps; since pnpm 10 blocks dependency lifecycle scripts by default, `esbuild` is added to `onlyBuiltDependencies` to keep the JS build working (the lockfile is unchanged — v9.0 format is shared by pnpm 9 and 10).

Sets `minimumReleaseAge: 4320` (3 days) so newly published versions have time to be caught and unpublished before we install them, with `e2b` excluded since we control its releases — Renovate gets a matching floor and exemption, otherwise it would propose versions pnpm then refuses to install.

Finally, moves the pnpm, Node, and Bun versions into `.tool-versions` alongside the Python and Poetry entries already wired up there; Node had been hardcoded in seven places at three different versions, and the release job keeps its explicit Node 24 pin, which is deliberate for npm 11 OIDC trusted publishing (#259).

Verified locally on pnpm 10.34.5: `install --frozen-lockfile` from a clean `node_modules`, `js build`, and `js lint` all pass, and the `.tool-versions` parser emits all five `TOOL_VERSION_*` vars with a parse step confirmed present earlier in every job that references one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)