### PR TITLE
fix(ci): tag the version bump, survive push races, release on dispatch

### DIFF
--- a/.github/scripts/build_release_itinerary.cjs
+++ b/.github/scripts/build_release_itinerary.cjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+// This script formats the JSON written by `changeset status --output=<file>`
+// as the package list that goes into the release's Slack notifications.
+
+const path = require('path')
+
+// Packages are listed in this order; anything not named here still shows up,
+// under its workspace name, after the ones that are.
+const labels = {
+  '@e2b/code-interpreter': 'JS SDK (@e2b/code-interpreter)',
+  '@e2b/code-interpreter-python': 'Python SDK (e2b-code-interpreter)',
+  '@e2b/data-extractor': 'Charts (e2b-charts)',
+  '@e2b/code-interpreter-template': 'Sandbox template (code-interpreter)',
+}
+
+const statusFile = process.argv[2]
+if (!statusFile) {
+  console.error('Usage: build_release_itinerary.cjs <changeset-status.json>')
+  process.exit(1)
+}
+
+const order = Object.keys(labels)
+const rank = (release) => {
+  const index = order.indexOf(release.name)
+  return index === -1 ? order.length : index
+}
+
+const { releases } = require(path.resolve(statusFile))
+const lines = [...releases]
+  .sort((a, b) => rank(a) - rank(b))
+  .map(
+    (release) =>
+      `• ${labels[release.name] ?? release.name} v${release.newVersion}`
+  )
+
+process.stdout.write(lines.join('\n') || '• No packages were published')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  # A release that publishes nothing leaves the changesets intact, so it can be
+  # re-dispatched by hand without another push to main.
+  workflow_dispatch: {}
 
 concurrency: Release-${{ github.ref }}-foxtrot
 
@@ -12,25 +15,35 @@ permissions:
   contents: write
 
 jobs:
-  is_release:
-    name: Is release?
+  preflight:
+    name: Release preflight
     runs-on: ubuntu-latest
     outputs:
       release: ${{ steps.version.outputs.release }}
+      js: ${{ steps.js.outputs.release }}
+      python: ${{ steps.python.outputs.release }}
+      charts: ${{ steps.charts.outputs.release }}
+      template: ${{ steps.template.outputs.release }}
+      itinerary: ${{ steps.itinerary.outputs.itinerary }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        id: pnpm-install
+      - name: Parse .tool-versions
+        uses: wistia/parse-tool-versions@v2.1.1
         with:
-          version: 9.5
+          filename: '.tool-versions'
+          uppercase: 'true'
+          prefix: 'tool_version_'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        id: pnpm-install
 
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "22.x"
+          node-version: '${{ env.TOOL_VERSION_NODEJS }}'
           registry-url: "https://registry.npmjs.org"
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
@@ -49,70 +62,63 @@ jobs:
           IS_RELEASE=$(./.github/scripts/is_release.sh)
           echo "release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
 
-  changes:
-    name: Repository changes
-    needs: [is_release]
-    if: needs.is_release.outputs.release == 'true'
-    runs-on: ubuntu-latest
-    outputs:
-      js: ${{ steps.js.outputs.release }}
-      python: ${{ steps.python.outputs.release }}
-      charts: ${{ steps.charts.outputs.release }}
-      template: ${{ steps.template.outputs.release }}
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        id: pnpm-install
-        with:
-          version: 9.5
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: "22.x"
-          registry-url: "https://registry.npmjs.org"
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Configure pnpm
-        run: |
-          pnpm config set auto-install-peers true
-          pnpm config set exclude-links-from-lockfile true
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Check JavasScript SDK Release
+      - name: Check JavaScript SDK Release
         id: js
+        if: steps.version.outputs.release == 'true'
         run: |
           IS_RELEASE=$(./.github/scripts/is_release_for_package.sh "@e2b/code-interpreter")
           echo "release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
 
       - name: Check Python SDK Release
         id: python
+        if: steps.version.outputs.release == 'true'
         run: |
           IS_RELEASE=$(./.github/scripts/is_release_for_package.sh "@e2b/code-interpreter-python")
           echo "release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
 
       - name: Check Charts SDK Release
         id: charts
+        if: steps.version.outputs.release == 'true'
         run: |
           IS_RELEASE=$(./.github/scripts/is_release_for_package.sh "@e2b/data-extractor")
           echo "release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
 
       - name: Check Template SDK Release
         id: template
+        if: steps.version.outputs.release == 'true'
         run: |
           IS_RELEASE=$(./.github/scripts/is_release_for_package.sh "@e2b/code-interpreter-template")
           echo "release=$IS_RELEASE" >> "$GITHUB_OUTPUT"
 
+      - name: Build release itinerary
+        id: itinerary
+        if: steps.version.outputs.release == 'true'
+        run: |
+          pnpm changeset status --output=.cs-status.json
+          ITINERARY=$(node -e '
+            const data = require("./.cs-status.json");
+            const labels = {
+              "@e2b/code-interpreter": "JS SDK (@e2b/code-interpreter)",
+              "@e2b/code-interpreter-python": "Python SDK (e2b-code-interpreter)",
+              "@e2b/data-extractor": "Charts (e2b-charts)",
+              "@e2b/code-interpreter-template": "Sandbox template (code-interpreter)",
+            };
+            const order = Object.keys(labels);
+            const byName = Object.fromEntries(data.releases.map(r => [r.name, r]));
+            const lines = order.filter(n => byName[n]).map(n => `• ${labels[n]} v${byName[n].newVersion}`);
+            process.stdout.write(lines.join("\n") || "• No packages were published");
+          ')
+          rm -f .cs-status.json
+          {
+            echo "itinerary<<EOF"
+            echo "$ITINERARY"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
   charts-release:
     name: Charts release
-    needs: [changes]
-    if: needs.changes.outputs.charts == 'true'
+    needs: [preflight]
+    if: needs.preflight.outputs.charts == 'true'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.output_version.outputs.version }}
@@ -128,10 +134,8 @@ jobs:
           prefix: 'tool_version_'
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         id: pnpm-install
-        with:
-          version: 9.5
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -173,16 +177,15 @@ jobs:
         id: output_version
         working-directory: ./chart_data_extractor
         run: |
-          echo "::set-output name=version::$(pnpm pkg get version --workspaces=false | tr -d \\\")"
+          echo "version=$(pnpm pkg get version --workspaces=false | tr -d \\\")" >> "$GITHUB_OUTPUT"
 
   build-docker-image:
     name: Build Docker Image
     runs-on: ubuntu-latest
-    needs: [changes, charts-release]
-    if: always() &&
+    needs: [preflight, charts-release]
+    if: (!cancelled()) &&
       !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
-      (needs.changes.outputs.template == 'true' || needs.changes.outputs.charts == 'true')
+      (needs.preflight.outputs.template == 'true' || needs.preflight.outputs.charts == 'true')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -234,11 +237,10 @@ jobs:
   build-template:
     name: Build E2B template
     runs-on: ubuntu-latest
-    needs: [build-docker-image]
-    if: always() &&
+    needs: [preflight, build-docker-image]
+    if: (!cancelled()) &&
       !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
-      (needs.changes.outputs.template == 'true' || needs.changes.outputs.charts == 'true')
+      (needs.preflight.outputs.template == 'true' || needs.preflight.outputs.charts == 'true')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -269,30 +271,30 @@ jobs:
 
   python-tests:
     name: Python Tests
-    needs: [changes, build-template]
-    if: always() &&
+    needs: [preflight, build-template]
+    if: (!cancelled()) &&
       !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
-      needs.changes.outputs.template == 'true'
+      needs.preflight.outputs.template == 'true'
     uses: ./.github/workflows/python_tests.yml
     secrets: inherit
 
   js-tests:
     name: JS Tests
-    needs: [changes, build-template]
-    if: always() &&
+    needs: [preflight, build-template]
+    if: (!cancelled()) &&
       !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
-      needs.changes.outputs.template == 'true'
+      needs.preflight.outputs.template == 'true'
     uses: ./.github/workflows/js_tests.yml
     secrets: inherit
 
   release:
-    needs: [python-tests, js-tests]
-    if: always() &&
+    # Every upstream job is listed, not just the tests: a job that fails makes its
+    # dependents *skip*, and a skipped test job is not a failure — so gating on
+    # `needs.*.result` only works for the jobs this one depends on directly.
+    needs: [preflight, charts-release, build-docker-image, build-template, python-tests, js-tests]
+    if: (!cancelled()) &&
       !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled') &&
-      (needs.changes.outputs.js == 'true' || needs.changes.outputs.python == 'true' || needs.changes.outputs.charts == 'true' || needs.changes.outputs.template == 'true')
+      needs.preflight.outputs.release == 'true'
     name: Release
     runs-on: ubuntu-latest
     steps:
@@ -327,14 +329,12 @@ jobs:
           virtualenvs-in-project: true
           installer-parallel: true
 
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 9.5
+      - uses: pnpm/action-setup@v4
 
-      - name: Setup Node.js 24
+      - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "24.x"
+          node-version: '${{ env.TOOL_VERSION_NODEJS }}'
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
 
@@ -351,6 +351,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Commit new versions
+        # Commit before publishing, because `changeset publish` tags whatever HEAD
+        # it publishes from — tagging afterwards is what left every tag on the
+        # commit before its own version bump (SDK-298). Nothing in the tree
+        # references the artifacts about to be uploaded — `changeset version`
+        # leaves `pnpm-lock.yaml` untouched here, since no workspace package
+        # depends on another — so the commit is already complete. It stays local
+        # until something is actually published, so a publish that uploads
+        # nothing leaves the branch untouched and the changesets intact for a
+        # re-run.
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # `add -A`, not `commit -a`: `changeset version` writes each package's
+          # CHANGELOG.md as a new file the first time, which `-a` would drop.
+          git add -A
+          if git diff --cached --quiet; then
+            echo "::error::'changeset version' produced no changes, so there is no version bump to publish or tag."
+            exit 1
+          fi
+          git commit -m "[skip ci] Release new versions"
+
       - name: Release new versions
         uses: changesets/action@v1
         with:
@@ -361,29 +384,78 @@ jobs:
           NPM_TOKEN: "" # See https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
 
-      - name: Update lock file
-        run: pnpm i --no-link --no-frozen-lockfile
-
-      - name: Commit new versions
+      - name: Push new versions
+        # Gate on the tags rather than on whether the publish step succeeded: they
+        # are what has to end up reachable. `changeset publish` tags at HEAD and the
+        # step above pushes them to origin, so if any exist — even from a publish
+        # that then failed partway — the commit they point at has to land, or they
+        # hang off no branch, which is the SDK-298 breakage this change prevents.
+        if: always()
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -am "[skip ci] Release new versions" || exit 0
-          git push
+          if [ -z "$(git tag --points-at HEAD)" ]; then
+            echo "Nothing was published; the version bump stays local and the changesets are intact for a re-run."
+            exit 0
+          fi
+
+          if ! git push; then
+            # A PR merged mid-release. Merge rather than rebase: the tags already
+            # point at this commit and rewriting it would strand them off the branch.
+            git fetch origin "${GITHUB_REF_NAME}"
+            git merge --no-edit FETCH_HEAD
+            git push
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  report-start:
+    needs: [preflight]
+    if: needs.preflight.outputs.release == 'true'
+    name: Code Interpreter Release Started - Slack Notification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release Started - Slack Notification
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2.4.0
+        env:
+          SLACK_COLOR: "#3aa3e3"
+          SLACK_MESSAGE: |
+            :rocket: A new release has been triggered :hourglass_flowing_sand:
+
+            *Releasing:*
+            ${{ needs.preflight.outputs.itinerary }}
+          SLACK_TITLE: Code Interpreter Release Started
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: "monitoring-releases"
+
   report-failure:
-    needs: [python-tests, js-tests, release]
+    needs: [charts-release, build-docker-image, build-template, python-tests, js-tests, release]
     if: failure()
     name: Code Interpreter Release Failed - Slack Notification
     runs-on: ubuntu-latest
     steps:
       - name: Release Failed - Slack Notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2.4.0
         env:
           SLACK_COLOR: "#ff0000"
           SLACK_MESSAGE: ":here-we-go-again: :bob-the-destroyer: We need :fix-parrot: ASAP :pray:"
           SLACK_TITLE: Code Interpreter Release Failed
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_CHANNEL: "monitoring-releases"
+
+  report-success:
+    needs: [preflight, release]
+    if: (!cancelled()) && needs.release.result == 'success'
+    name: Code Interpreter Release Succeeded - Slack Notification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release Succeeded - Slack Notification
+        uses: rtCamp/action-slack-notify@33ca3be66c6f378fe1610fd1d5258632dbed5e58 # v2.4.0
+        env:
+          SLACK_COLOR: "#36a64f"
+          SLACK_MESSAGE: |
+            :tada: A new version has been released successfully! :ship-it-parrot:
+
+            *Released:*
+            ${{ needs.preflight.outputs.itinerary }}
+          SLACK_TITLE: Code Interpreter Release Succeeded
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: "monitoring-releases"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -405,13 +405,6 @@ jobs:
             git merge --no-edit FETCH_HEAD
             git push
           fi
-
-          # `changesets/action` only pushes the tags it can parse out of
-          # `changeset publish`'s output, so push whatever else ended up at the
-          # release commit. The checkout is shallow and fetches no tags, so the
-          # only local tags are the ones this run created, and re-pushing the
-          # ones the action already sent is a no-op.
-          git push --tags
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,17 @@ jobs:
       template: ${{ steps.template.outputs.release }}
       itinerary: ${{ steps.itinerary.outputs.itinerary }}
     steps:
+      - name: Check the ref
+        # `workflow_dispatch` offers every branch in the picker, and a feature
+        # branch carrying changesets would otherwise publish real packages and
+        # push the version bump to that branch.
+        if: github.ref != 'refs/heads/main'
+        env:
+          REF: ${{ github.ref }}
+        run: |
+          echo "::error::Releases must run on main; this run is on ${REF}."
+          exit 1
+
       - name: Checkout Repo
         uses: actions/checkout@v4
 
@@ -93,21 +104,12 @@ jobs:
       - name: Build release itinerary
         id: itinerary
         if: steps.version.outputs.release == 'true'
+        # This only feeds the Slack notifications, so it must never be the thing
+        # that blocks a release; the messages fall back to a placeholder.
+        continue-on-error: true
         run: |
           pnpm changeset status --output=.cs-status.json
-          ITINERARY=$(node -e '
-            const data = require("./.cs-status.json");
-            const labels = {
-              "@e2b/code-interpreter": "JS SDK (@e2b/code-interpreter)",
-              "@e2b/code-interpreter-python": "Python SDK (e2b-code-interpreter)",
-              "@e2b/data-extractor": "Charts (e2b-charts)",
-              "@e2b/code-interpreter-template": "Sandbox template (code-interpreter)",
-            };
-            const order = Object.keys(labels);
-            const byName = Object.fromEntries(data.releases.map(r => [r.name, r]));
-            const lines = order.filter(n => byName[n]).map(n => `• ${labels[n]} v${byName[n].newVersion}`);
-            process.stdout.write(lines.join("\n") || "• No packages were published");
-          ')
+          ITINERARY=$(node ./.github/scripts/build_release_itinerary.cjs .cs-status.json)
           rm -f .cs-status.json
           {
             echo "itinerary<<EOF"
@@ -404,6 +406,13 @@ jobs:
             git merge --no-edit FETCH_HEAD
             git push
           fi
+
+          # `changesets/action` only pushes the tags it can parse out of
+          # `changeset publish`'s output, so push whatever else ended up at the
+          # release commit. The checkout is shallow and fetches no tags, so the
+          # only local tags are the ones this run created, and re-pushing the
+          # ones the action already sent is a no-op.
+          git push --tags
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -421,7 +430,7 @@ jobs:
             :rocket: A new release has been triggered :hourglass_flowing_sand:
 
             *Releasing:*
-            ${{ needs.preflight.outputs.itinerary }}
+            ${{ needs.preflight.outputs.itinerary || '• (itinerary unavailable)' }}
           SLACK_TITLE: Code Interpreter Release Started
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: "monitoring-releases"
@@ -455,7 +464,7 @@ jobs:
             :tada: A new version has been released successfully! :ship-it-parrot:
 
             *Released:*
-            ${{ needs.preflight.outputs.itinerary }}
+            ${{ needs.preflight.outputs.itinerary || '• (itinerary unavailable)' }}
           SLACK_TITLE: Code Interpreter Release Succeeded
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: "monitoring-releases"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -435,7 +435,9 @@ jobs:
           SLACK_CHANNEL: "monitoring-releases"
 
   report-failure:
-    needs: [charts-release, build-docker-image, build-template, python-tests, js-tests, release]
+    # `preflight` included so a failure there is reported too, whether or not
+    # `failure()` looks past this job's direct dependencies.
+    needs: [preflight, charts-release, build-docker-image, build-template, python-tests, js-tests, release]
     if: failure()
     name: Code Interpreter Release Failed - Slack Notification
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,10 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
-  # A release that publishes nothing leaves the changesets intact, so it can be
-  # re-dispatched by hand without another push to main.
+  # Releases are cut by hand, as in e2b-dev/E2B: merging a changeset to main no
+  # longer publishes on its own, so changesets accumulate until someone
+  # dispatches this. A release that publishes nothing leaves them intact, which
+  # makes a re-dispatch the recovery path too.
   workflow_dispatch: {}
 
 concurrency: Release-${{ github.ref }}-foxtrot

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
+nodejs 24
 python 3.10
 poetry 2.1.1


### PR DESCRIPTION
Ports the release-workflow fixes from `e2b-dev/E2B` (#1463, #1469, #1484, #1589, #1619), which its own PR flagged as applying here too, and switches this repo to E2B's process: **releases are cut by dispatching the workflow, not by merging to `main`**.

Every release tag in this repo points at the commit *before* its own version bump (`@e2b/code-interpreter@2.7.0` contains `"version": "2.6.1"`) because `changesets/action` tags whatever HEAD it publishes from, so the version commit now happens *before* the publish — safe here because `changeset version` leaves `pnpm-lock.yaml` untouched (no workspace package depends on a sibling), which also deletes the `Update lock file` step; the push that follows is gated on `git tag --points-at HEAD` and reconciles a non-fast-forward with a merge rather than a rebase, the exact race that killed run 30018789653 with the versions already published, and `git add -A` replaces `commit -am`, which cannot stage the `CHANGELOG.md` files `changeset version` writes fresh.

Also included: Slack start/success notifications with a release itinerary (built by `.github/scripts/build_release_itinerary.cjs`, non-blocking), `is_release` + `changes` collapsed into a single `preflight` job that refuses to run off `main`, `always()` → `!cancelled()` so the workflow can actually be cancelled, pnpm taken from `packageManager` and Node from `.tool-versions` instead of drifting pins, and `::set-output` replaced with `$GITHUB_OUTPUT`. Two latent bugs are fixed on the way: `build-template` and `release` read `needs.changes.outputs.*` without depending on `changes`, and `release`'s `!contains(needs.*.result, 'failure')` could not see a template or docker failure — a failed upstream makes the test jobs *skip*, and skipped is not failure — so a broken template build could publish; every upstream job is now listed in `needs`.

Verified by rehearsing the git logic against a throwaway shallow clone and bare origin with a commit pushed mid-release: the tags land on the bump (`@e2b/code-interpreter@2.7.1` → `"version": "2.7.1"`), stay reachable from `main` through the merge fallback, and a publish that uploads nothing leaves origin untouched with the changesets intact. Left alone deliberately: `release_candidates.yml` (a different, label-driven shape) and the test gating, which still runs JS/Python tests only when the template changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)