### PR TITLE
chore: tag e2b.dev links with UTM parameters

### DIFF
--- a/.changeset/tag-e2b-links-with-utm.md
+++ b/.changeset/tag-e2b-links-with-utm.md
@@ -1,5 +1,6 @@
 ---
 '@e2b/code-interpreter': patch
+'@e2b/code-interpreter-python': patch
 ---
 
 Tag the e2b.dev links in the README and the package homepage field with UTM parameters so registry-page traffic attributes to its source

--- a/.changeset/tag-e2b-links-with-utm.md
+++ b/.changeset/tag-e2b-links-with-utm.md
@@ -1,0 +1,5 @@
+---
+'@e2b/code-interpreter': patch
+---
+
+Tag the e2b.dev links in the README and the package homepage field with UTM parameters so registry-page traffic attributes to its source

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <img width="100%" src="/readme-assets/preview.png" alt="Cover image">
 --->
 ## What is E2B?
-[E2B](https://www.e2b.dev/) is an open-source infrastructure that allows you to run AI-generated code in secure isolated sandboxes in the cloud. To start and control sandboxes, use our [JavaScript SDK](https://www.npmjs.com/package/@e2b/code-interpreter) or [Python SDK](https://pypi.org/project/e2b_code_interpreter).
+[E2B](https://e2b.dev/?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=code-interpreter) is an open-source infrastructure that allows you to run AI-generated code in secure isolated sandboxes in the cloud. To start and control sandboxes, use our [JavaScript SDK](https://www.npmjs.com/package/@e2b/code-interpreter) or [Python SDK](https://pypi.org/project/e2b_code_interpreter).
 
 ## Run your first Sandbox
 
@@ -37,8 +37,8 @@ pip install e2b-code-interpreter
 ```
 
 ### 2. Get your E2B API key
-1. Sign up to E2B [here](https://e2b.dev).
-2. Get your API key [here](https://e2b.dev/dashboard?tab=keys).
+1. Sign up to E2B [here](https://e2b.dev/?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=code-interpreter).
+2. Get your API key [here](https://e2b.dev/dashboard?tab=keys&utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=code-interpreter).
 3. Set environment variable with your API key.
 ```
 E2B_API_KEY=e2b_***
@@ -68,7 +68,7 @@ with Sandbox.create() as sandbox:
 ```
 
 ### 4. Check docs
-Visit [E2B documentation](https://e2b.dev/docs).
+Visit [E2B documentation](https://e2b.dev/docs?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=code-interpreter).
 
 ### 5. E2B cookbook
 Visit our [Cookbook](https://github.com/e2b-dev/e2b-cookbook/tree/main) to get inspired by examples with different LLMs and AI frameworks.

--- a/js/README.md
+++ b/js/README.md
@@ -13,7 +13,7 @@
 <img width="100%" src="/readme-assets/preview.png" alt="Cover image">
 --->
 ## What is E2B?
-[E2B](https://www.e2b.dev/) is an open-source infrastructure that allows you run to AI-generated code in secure isolated sandboxes in the cloud. To start and control sandboxes, use our [JavaScript SDK](https://www.npmjs.com/package/@e2b/code-interpreter) or [Python SDK](https://pypi.org/project/e2b_code_interpreter).
+[E2B](https://e2b.dev/?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=code-interpreter) is an open-source infrastructure that allows you run to AI-generated code in secure isolated sandboxes in the cloud. To start and control sandboxes, use our [JavaScript SDK](https://www.npmjs.com/package/@e2b/code-interpreter) or [Python SDK](https://pypi.org/project/e2b_code_interpreter).
 
 ## Run your first Sandbox
 
@@ -24,8 +24,8 @@ npm i @e2b/code-interpreter
 ```
 
 ### 2. Get your E2B API key
-1. Sign up to E2B [here](https://e2b.dev).
-2. Get your API key [here](https://e2b.dev/dashboard?tab=keys).
+1. Sign up to E2B [here](https://e2b.dev/?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=code-interpreter).
+2. Get your API key [here](https://e2b.dev/dashboard?tab=keys&utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=code-interpreter).
 3. Set environment variable with your API key.
 ```
 E2B_API_KEY=e2b_***
@@ -44,7 +44,7 @@ console.log(execution.text)  // outputs 2
 ```
 
 ### 4. Check docs
-Visit [E2B documentation](https://e2b.dev/docs).
+Visit [E2B documentation](https://e2b.dev/docs?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=code-interpreter).
 
 ### 5. E2B cookbook
 Visit our [Cookbook](https://github.com/e2b-dev/e2b-cookbook/tree/main) to get inspired by examples with different LLMs and AI frameworks.

--- a/js/package.json
+++ b/js/package.json
@@ -3,7 +3,7 @@
   "version": "2.7.1",
   "packageManager": "pnpm@10.34.5",
   "description": "E2B Code Interpreter - Stateful code execution",
-  "homepage": "https://e2b.dev",
+  "homepage": "https://e2b.dev/?utm_source=npm&utm_medium=referral&utm_campaign=package_homepage&utm_content=e2b-code-interpreter",
   "license": "MIT",
   "author": {
     "name": "FoundryLabs, Inc.",

--- a/python/README.md
+++ b/python/README.md
@@ -13,7 +13,7 @@
 <img width="100%" src="/readme-assets/preview.png" alt="Cover image">
 --->
 ## What is E2B?
-[E2B](https://www.e2b.dev/) is an open-source infrastructure that allows you run to AI-generated code in secure isolated sandboxes in the cloud. To start and control sandboxes, use our [JavaScript SDK](https://www.npmjs.com/package/@e2b/code-interpreter) or [Python SDK](https://pypi.org/project/e2b_code_interpreter).
+[E2B](https://e2b.dev/?utm_source=pypi&utm_medium=referral&utm_campaign=readme&utm_content=code-interpreter) is an open-source infrastructure that allows you run to AI-generated code in secure isolated sandboxes in the cloud. To start and control sandboxes, use our [JavaScript SDK](https://www.npmjs.com/package/@e2b/code-interpreter) or [Python SDK](https://pypi.org/project/e2b_code_interpreter).
 
 ## Run your first Sandbox
 
@@ -24,8 +24,8 @@ pip install e2b-code-interpreter
 ```
 
 ### 2. Get your E2B API key
-1. Sign up to E2B [here](https://e2b.dev).
-2. Get your API key [here](https://e2b.dev/dashboard?tab=keys).
+1. Sign up to E2B [here](https://e2b.dev/?utm_source=pypi&utm_medium=referral&utm_campaign=readme&utm_content=code-interpreter).
+2. Get your API key [here](https://e2b.dev/dashboard?tab=keys&utm_source=pypi&utm_medium=referral&utm_campaign=readme&utm_content=code-interpreter).
 3. Set environment variable with your API key.
 ```
 E2B_API_KEY=e2b_***
@@ -43,7 +43,7 @@ with Sandbox.create() as sandbox:
 ```
 
 ### 4. Check docs
-Visit [E2B documentation](https://e2b.dev/docs).
+Visit [E2B documentation](https://e2b.dev/docs?utm_source=pypi&utm_medium=referral&utm_campaign=readme&utm_content=code-interpreter).
 
 ### 5. E2B cookbook
 Visit our [Cookbook](https://github.com/e2b-dev/e2b-cookbook/tree/main) to get inspired by examples with different LLMs and AI frameworks.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,7 +5,7 @@ description = "E2B Code Interpreter - Stateful code execution"
 authors = ["e2b <hello@e2b.dev>"]
 license = "MIT"
 readme = "README.md"
-homepage = "https://e2b.dev/"
+homepage = "https://e2b.dev/?utm_source=pypi&utm_medium=referral&utm_campaign=package_homepage&utm_content=e2b-code-interpreter"
 repository = "https://github.com/e2b-dev/code-interpreter/tree/main/python"
 packages = [{ include = "e2b_code_interpreter" }]
 


### PR DESCRIPTION
READMEs follow the org's existing utm_campaign=readme convention. The package homepage fields get utm_source=pypi/npm so installs coming from registry pages attribute to their real source — that part takes effect on the next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)