### PR TITLE
chore: point README docs links at docs.e2b.dev

### DIFF
--- a/.changeset/docs-subdomain-links.md
+++ b/.changeset/docs-subdomain-links.md
@@ -1,0 +1,6 @@
+---
+'@e2b/code-interpreter': patch
+'@e2b/code-interpreter-python': patch
+---
+
+Point the README documentation links at `docs.e2b.dev` instead of `e2b.dev/docs`. The docs site moved to its own subdomain and the old path has no `/docs` prefix there, so `e2b.dev/docs` now serves a 308 to `docs.e2b.dev/`. The UTM parameters are unchanged and survived the redirect, so this removes a redirect hop rather than fixing broken attribution.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ with Sandbox.create() as sandbox:
 ```
 
 ### 4. Check docs
-Visit [E2B documentation](https://e2b.dev/docs?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=code-interpreter).
+Visit [E2B documentation](https://docs.e2b.dev/?utm_source=github&utm_medium=referral&utm_campaign=readme&utm_content=code-interpreter).
 
 ### 5. E2B cookbook
 Visit our [Cookbook](https://github.com/e2b-dev/e2b-cookbook/tree/main) to get inspired by examples with different LLMs and AI frameworks.

--- a/js/README.md
+++ b/js/README.md
@@ -44,7 +44,7 @@ console.log(execution.text)  // outputs 2
 ```
 
 ### 4. Check docs
-Visit [E2B documentation](https://e2b.dev/docs?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=code-interpreter).
+Visit [E2B documentation](https://docs.e2b.dev/?utm_source=npm&utm_medium=referral&utm_campaign=readme&utm_content=code-interpreter).
 
 ### 5. E2B cookbook
 Visit our [Cookbook](https://github.com/e2b-dev/e2b-cookbook/tree/main) to get inspired by examples with different LLMs and AI frameworks.

--- a/python/README.md
+++ b/python/README.md
@@ -43,7 +43,7 @@ with Sandbox.create() as sandbox:
 ```
 
 ### 4. Check docs
-Visit [E2B documentation](https://e2b.dev/docs?utm_source=pypi&utm_medium=referral&utm_campaign=readme&utm_content=code-interpreter).
+Visit [E2B documentation](https://docs.e2b.dev/?utm_source=pypi&utm_medium=referral&utm_campaign=readme&utm_content=code-interpreter).
 
 ### 5. E2B cookbook
 Visit our [Cookbook](https://github.com/e2b-dev/e2b-cookbook/tree/main) to get inspired by examples with different LLMs and AI frameworks.


### PR DESCRIPTION
Follow-up to #330. The docs site moved to its own subdomain, so the links that PR tagged point at the pre-migration domain.

`e2b.dev/docs` returns a 308 to `docs.e2b.dev/`, and the subdomain has no `/docs` path prefix, so `e2b.dev/docs/<path>` maps to `docs.e2b.dev/<path>`.

The UTM query string is preserved across the redirect, so attribution was not broken. This removes the redirect hop.

Three links, one per README. Changeset covers both SDK packages, since `js/README.md` and `python/README.md` ship to npm and PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)