### PR TITLE
fix(server): don't silently swallow WebSocket message processing errors

### DIFF
--- a/template/server/messaging.py
+++ b/template/server/messaging.py
@@ -426,7 +426,43 @@ class ContextWebSocket:
 
         try:
             async for message in self._ws:
-                await self._process_message(json.loads(message))
+                try:
+                    data = json.loads(message)
+                    await self._process_message(data)
+                except (ConnectionClosedError, WebSocketException):
+                    # Connection-level failures are handled below and must
+                    # terminate the receive loop so ongoing executions are
+                    # cancelled instead of hanging forever.
+                    raise
+                except Exception as e:
+                    # A single malformed or unexpected message must not kill
+                    # the receive loop nor be silently swallowed. Log the full
+                    # stack trace together with the raw message so it can be
+                    # diagnosed, and notify the affected execution so it does
+                    # not hang waiting for results.
+                    logger.exception(
+                        "Error while processing WebSocket message: %s (message: %s)",
+                        e,
+                        message[:500],
+                    )
+                    parent_msg_id = None
+                    try:
+                        parent_msg_id = json.loads(message).get(
+                            "parent_header", {}
+                        ).get("msg_id")
+                    except Exception:
+                        pass
+                    if parent_msg_id:
+                        execution = self._executions.get(parent_msg_id)
+                        if execution:
+                            await execution.queue.put(
+                                Error(
+                                    name="MessageProcessingError",
+                                    value=f"Failed to process kernel message: {e}",
+                                    traceback="",
+                                )
+                            )
+                            await execution.queue.put(EndOfExecution())
         except Exception as e:
             logger.error(f"WebSocket received error while receiving messages: {str(e)}")
         finally:


### PR DESCRIPTION
Fixes #336

## Problem

`ContextWebSocket._receive_message()` processes every WebSocket message with no per-message error isolation:

```python
async for message in self._ws:
    await self._process_message(json.loads(message))
```

A single malformed or unexpected message (bad JSON, missing `content`/`header` field, unexpected structure) raises inside the loop, which:

1. Logs only `WebSocket received error while receiving messages: <str(e)>` — no stack trace, no message content → the real cause is silently swallowed.
2. Terminates the `async for` loop → `_receive_task` exits → all subsequent kernel messages are never processed and the connection is never re-established.
3. Runs the `finally` block which marks **every** in-flight execution as `WebSocketError` + `UnexpectedEndOfExecution` ("The connections was lost..."), even though the connection itself is healthy.

## Fix

Isolate per-message handling in an inner `try/except`:

- **Connection-level failures** (`ConnectionClosedError` / `WebSocketException`) are re-raised so the outer handler still terminates the loop and cancels all ongoing executions — unchanged behavior for real disconnects.
- **Any other per-message exception** now:
  - logs the full stack trace plus a preview of the raw message (`logger.exception`), so the failure is no longer silent,
  - notifies the affected execution with a `MessageProcessingError` + `EndOfExecution` so that execution ends with a clear error instead of hanging,
  - lets the receive loop continue processing subsequent messages.

## Testing

- `python3 -m py_compile template/server/messaging.py` passes.
- Behavior verified by reasoning over the existing flow: connection errors still re-raise into the outer handler; per-message errors are contained and surfaced to the corresponding execution.

## Notes

- Message preview is truncated to 500 chars to avoid logging huge payloads.
- `EndOfExecution` is sent after `MessageProcessingError` so the client's `_wait_for_result` loop terminates (it breaks on `END_OF_EXECUTION`).